### PR TITLE
[Feature/Bug] 일반 게시글 저장 및 수정/권한 확인 함수 오류 수정

### DIFF
--- a/src/main/java/org/triumers/kmsback/common/exception/NotAuthorizedException.java
+++ b/src/main/java/org/triumers/kmsback/common/exception/NotAuthorizedException.java
@@ -1,0 +1,7 @@
+package org.triumers.kmsback.common.exception;
+
+public class NotAuthorizedException extends CustomException {
+    public NotAuthorizedException() {
+        super("권한이 없습니다.");
+    }
+}

--- a/src/main/java/org/triumers/kmsback/post/command/Application/controller/CmdPostController.java
+++ b/src/main/java/org/triumers/kmsback/post/command/Application/controller/CmdPostController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.triumers.kmsback.common.exception.NotAuthorizedException;
 import org.triumers.kmsback.common.exception.NotLoginException;
 import org.triumers.kmsback.post.command.Application.dto.CmdFavoritesDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdLikeDTO;
@@ -44,7 +45,7 @@ public class CmdPostController {
     }
 
     @DeleteMapping("/delete/{id}")
-    public ResponseEntity<CmdPostAndTagsDTO> deletePost(@PathVariable int id) throws NotLoginException {
+    public ResponseEntity<CmdPostAndTagsDTO> deletePost(@PathVariable int id) throws NotLoginException, NotAuthorizedException {
 
         CmdPostAndTagsDTO deletedPost = cmdPostService.deletePost(id);
 

--- a/src/main/java/org/triumers/kmsback/post/command/Application/service/CmdPostService.java
+++ b/src/main/java/org/triumers/kmsback/post/command/Application/service/CmdPostService.java
@@ -1,5 +1,6 @@
 package org.triumers.kmsback.post.command.Application.service;
 
+import org.triumers.kmsback.common.exception.NotAuthorizedException;
 import org.triumers.kmsback.common.exception.NotLoginException;
 import org.triumers.kmsback.post.command.Application.dto.CmdFavoritesDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdLikeDTO;
@@ -13,7 +14,7 @@ public interface CmdPostService {
 
     CmdPostAndTagsDTO modifyPost(CmdPostAndTagsDTO post) throws NotLoginException;
 
-    CmdPostAndTagsDTO deletePost(int postId) throws NotLoginException;
+    CmdPostAndTagsDTO deletePost(int postId) throws NotLoginException, NotAuthorizedException;
 
     CmdLikeDTO likePost(CmdLikeDTO like) throws NotLoginException;
 

--- a/src/main/java/org/triumers/kmsback/post/command/Application/service/CmdPostServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/post/command/Application/service/CmdPostServiceImpl.java
@@ -46,11 +46,15 @@ public class CmdPostServiceImpl implements CmdPostService {
     public CmdPostAndTagsDTO registPost(CmdPostAndTagsDTO post) throws NotLoginException {
 
         Auth employee = authService.whoAmI();
-        CmdPost registPost = new CmdPost(post.getTitle(), post.getContent(), post.getCreatedAt(),
+        CmdPost registPost = new CmdPost(post.getId(), post.getTitle(), post.getContent(), post.getCreatedAt(),
                 employee.getId(), post.getOriginId(), post.getTabRelationId(), post.getCategoryId());
+
+        if (post.getId() != null) {
+            cmdPostTagRepository.deleteByPostId(post.getId());
+        }
         cmdPostRepository.save(registPost);
 
-        List<CmdTag> tags = registTag(convertStringToTag(post.getTags()), registPost.getId());
+        registTag(convertStringToTag(post.getTags()), registPost.getId());
 
         post.setId(registPost.getId());
 

--- a/src/main/java/org/triumers/kmsback/post/command/domain/aggregate/entity/CmdPost.java
+++ b/src/main/java/org/triumers/kmsback/post/command/domain/aggregate/entity/CmdPost.java
@@ -65,6 +65,18 @@ public class CmdPost {
         this.categoryId = categoryId;
     }
 
+    public CmdPost(Integer id, String title, String content, LocalDateTime createdAt,
+                   Integer authorId, Integer originId, Integer tabRelationId, Integer categoryId) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.authorId = authorId;
+        this.originId = originId;
+        this.tabRelationId = tabRelationId;
+        this.categoryId = categoryId;
+    }
+
     public CmdPost(String title, String content, LocalDateTime createdAt, Integer authorId,
                    Integer originId, Integer tabRelationId, Integer categoryId) {
         this.title = title;

--- a/src/main/java/org/triumers/kmsback/post/command/domain/repository/CmdPostRepository.java
+++ b/src/main/java/org/triumers/kmsback/post/command/domain/repository/CmdPostRepository.java
@@ -1,10 +1,15 @@
 package org.triumers.kmsback.post.command.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.triumers.kmsback.post.command.domain.aggregate.entity.CmdPost;
 
+import java.util.Optional;
+
 @Repository
 public interface CmdPostRepository  extends JpaRepository<CmdPost, Integer> {
-    int findAuthorIdById(int originId);
+
+    @Query("select A.authorId from CmdPost A where A.id = :originId")
+    Integer findAuthorIdById(int originId);
 }

--- a/src/main/java/org/triumers/kmsback/post/command/domain/repository/CmdPostTagRepository.java
+++ b/src/main/java/org/triumers/kmsback/post/command/domain/repository/CmdPostTagRepository.java
@@ -7,5 +7,5 @@ import org.triumers.kmsback.post.command.domain.aggregate.entity.CmdPostTag;
 @Repository
 public interface CmdPostTagRepository extends JpaRepository<CmdPostTag, Integer> {
 
-
+    void deleteByPostId(Integer id);
 }

--- a/src/test/java/org/triumers/kmsback/post/command/Application/service/CmdPostServiceTests.java
+++ b/src/test/java/org/triumers/kmsback/post/command/Application/service/CmdPostServiceTests.java
@@ -1,13 +1,17 @@
 package org.triumers.kmsback.post.command.Application.service;
 
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.triumers.kmsback.common.LoggedInUser;
 import org.triumers.kmsback.common.ai.service.OpenAIService;
+import org.triumers.kmsback.common.exception.NotAuthorizedException;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputTypeException;
 import org.triumers.kmsback.post.command.Application.dto.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -21,115 +25,122 @@ public class CmdPostServiceTests {
 
     private final CmdPostService cmdPostService;
     private final OpenAIService openAIService;
+    private final LoggedInUser loggedInUser;
 
     @Autowired
-    public CmdPostServiceTests(CmdPostService cmdPostService, OpenAIService openAIService) {
+    public CmdPostServiceTests(CmdPostService cmdPostService, OpenAIService openAIService, LoggedInUser loggedInUser) {
         this.cmdPostService = cmdPostService;
         this.openAIService = openAIService;
+        this.loggedInUser = loggedInUser;
+    }
+
+    @BeforeEach
+    void loginSetting() throws WrongInputTypeException {
+        loggedInUser.setting();
+    }
+
+    @Test
+    @DisplayName("게시글 저장")
+    void registPost() throws NotLoginException {
+
+        CmdPostAndTagsDTO post = createTestPost("new");
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(post);
+
+        assertThat(savedPost.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 수정")
+    void modifyPost() throws NotLoginException {
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost("new"));
+
+        List<String> modifyTags = new ArrayList<>();
+        modifyTags.add("개발");
+        modifyTags.add("tag1");
+        modifyTags.add("tag2");
+        modifyTags.add("tag3");
+        modifyTags.add("tag4");
+
+        CmdPostAndTagsDTO modifyPost = createTestPost("modify");
+        modifyPost.setTags(modifyTags);
+        modifyPost.setOriginId(savedPost.getId());
+
+        cmdPostService.modifyPost(modifyPost);
+
+        assertThat(modifyPost.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 삭제")
+    void deletePost() throws NotLoginException, NotAuthorizedException {
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
+        CmdPostAndTagsDTO deletedPost = cmdPostService.deletePost(savedPost.getId());
+
+        assertThat(deletedPost.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요/삭제")
+    void likePost() throws NotLoginException {
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
+
+        CmdLikeDTO like = new CmdLikeDTO(1, savedPost.getId());
+        CmdLikeDTO likePost = cmdPostService.likePost(like);
+
+        assertThat(likePost.getId()).isNotNull();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("게시글 즐겨찾기/삭제")
+    void favoritePost() throws NotLoginException {
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
+
+        CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, savedPost.getId());
+        CmdFavoritesDTO likePost = cmdPostService.favoritePost(favorite);
+
+        assertThat(likePost.getId()).isNotNull();
     }
 
 //    @Test
-//    @DisplayName("게시글 저장")
-//    void registPost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO post = createTestPost("new");
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(post);
-//
-//        assertThat(savedPost.getId()).isNotNull();
+//    void testGPT(){
+//        String testContent = "<h1>Spring Boot와 GPT API를 이용한 챗봇 구축</h1>\n" +
+//        "    \n" +
+//        "    <h2>소개</h2>\n" +
+//        "    <p>이번 게시글에서는 Spring Boot와 OpenAI의 GPT API를 활용하여 챗봇을 개발하는 방법에 대해 알아봅니다. 챗봇은 사용자의 질문에 대해 인공지능 기술을 활용하여 응답하는 프로그램입니다. 이 프로젝트를 통해 Spring Boot 애플리케이션에서 GPT 모델을 적용하는 방법을 배울 수 있습니다.</p>\n" +
+//        "    \n" +
+//        "    <h2>프로젝트 설정</h2>\n" +
+//        "    <p>먼저 Spring Initializr를 이용하여 새로운 Spring Boot 프로젝트를 생성합니다. Web, Lombok, Spring Boot DevTools 의존성을 추가합니다. 그 후, 생성된 프로젝트에 OpenAI API 키를 설정합니다.</p>\n" +
+//        "\n" +
+//        "    <h2>서비스 작성</h2>\n" +
+//        "    <p>OpenAI API와 통신하는 서비스 클래스를 작성합니다. 이 클래스에서는 RestTemplate을 사용하여 OpenAI API에 요청을 보내고 응답을 받습니다.</p>\n" +
+//        "\n" +
+//        "    <h2>컨트롤러 작성</h2>\n" +
+//        "    <p>사용자의 요청을 받아 OpenAI API에 전달하고 응답을 반환하는 컨트롤러를 작성합니다. 이 컨트롤러는 RESTful API 엔드포인트로서 사용됩니다.</p>\n" +
+//        "\n" +
+//        "    <h2>테스트</h2>\n" +
+//        "    <p>애플리케이션을 실행하고 API를 호출하여 제대로 작동하는지 테스트합니다. Postman과 같은 도구를 사용하여 `POST` 요청을 보내어 응답을 확인할 수 있습니다.</p>";
+//        openAIService.requestToGPT("enhancement", testContent);
 //    }
-//
-//    @Test
-//    @DisplayName("게시글 수정")
-//    void modifyPost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost("new"));
-//
-//        List<String> modifyTags = new ArrayList<>();
-//        modifyTags.add("개발");
-//        modifyTags.add("tag1");
-//        modifyTags.add("tag2");
-//        modifyTags.add("tag3");
-//        modifyTags.add("tag4");
-//
-//        CmdPostAndTagsDTO modifyPost = createTestPost("modify");
-//        modifyPost.setTags(modifyTags);
-//        modifyPost.setOriginId(savedPost.getId());
-//
-//        cmdPostService.modifyPost(modifyPost);
-//
-//        assertThat(modifyPost.getId()).isNotNull();
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 삭제")
-//    void deletePost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
-//        CmdPostAndTagsDTO deletedPost = cmdPostService.deletePost(savedPost.getId());
-//
-//        assertThat(deletedPost.getDeletedAt()).isNotNull();
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 좋아요/삭제")
-//    void likePost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
-//
-//        CmdLikeDTO like = new CmdLikeDTO(1, savedPost.getId());
-//        CmdLikeDTO likePost = cmdPostService.likePost(like);
-//
-//        assertThat(likePost.getId()).isNotNull();
-//    }
-//
-//    @Test
-//    @Order(4)
-//    @DisplayName("게시글 즐겨찾기/삭제")
-//    void favoritePost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
-//
-//        CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, savedPost.getId());
-//        CmdFavoritesDTO likePost = cmdPostService.favoritePost(favorite);
-//
-//        assertThat(likePost.getId()).isNotNull();
-//    }
-//
-////    @Test
-////    void testGPT(){
-////        String testContent = "<h1>Spring Boot와 GPT API를 이용한 챗봇 구축</h1>\n" +
-////        "    \n" +
-////        "    <h2>소개</h2>\n" +
-////        "    <p>이번 게시글에서는 Spring Boot와 OpenAI의 GPT API를 활용하여 챗봇을 개발하는 방법에 대해 알아봅니다. 챗봇은 사용자의 질문에 대해 인공지능 기술을 활용하여 응답하는 프로그램입니다. 이 프로젝트를 통해 Spring Boot 애플리케이션에서 GPT 모델을 적용하는 방법을 배울 수 있습니다.</p>\n" +
-////        "    \n" +
-////        "    <h2>프로젝트 설정</h2>\n" +
-////        "    <p>먼저 Spring Initializr를 이용하여 새로운 Spring Boot 프로젝트를 생성합니다. Web, Lombok, Spring Boot DevTools 의존성을 추가합니다. 그 후, 생성된 프로젝트에 OpenAI API 키를 설정합니다.</p>\n" +
-////        "\n" +
-////        "    <h2>서비스 작성</h2>\n" +
-////        "    <p>OpenAI API와 통신하는 서비스 클래스를 작성합니다. 이 클래스에서는 RestTemplate을 사용하여 OpenAI API에 요청을 보내고 응답을 받습니다.</p>\n" +
-////        "\n" +
-////        "    <h2>컨트롤러 작성</h2>\n" +
-////        "    <p>사용자의 요청을 받아 OpenAI API에 전달하고 응답을 반환하는 컨트롤러를 작성합니다. 이 컨트롤러는 RESTful API 엔드포인트로서 사용됩니다.</p>\n" +
-////        "\n" +
-////        "    <h2>테스트</h2>\n" +
-////        "    <p>애플리케이션을 실행하고 API를 호출하여 제대로 작동하는지 테스트합니다. Postman과 같은 도구를 사용하여 `POST` 요청을 보내어 응답을 확인할 수 있습니다.</p>";
-////        openAIService.requestToGPT("enhancement", testContent);
-////    }
-//
-//    private CmdPostAndTagsDTO createTestPost(){
-//        return createTestPost("");
-//    }
-//
-//    private CmdPostAndTagsDTO createTestPost(String type){
-//        List<String> tags = new ArrayList<>();
-//        tags.add("개발");
-//        tags.add("tag1");
-//        tags.add("tag2");
-//        tags.add("tag3");
-//        tags.add("tag4");
-//
-//        return new CmdPostAndTagsDTO(type + "Title",  type + "Content", LocalDateTime.now(), 1, 1, tags);
-//    }
+
+    private CmdPostAndTagsDTO createTestPost(){
+        return createTestPost("");
+    }
+
+    private CmdPostAndTagsDTO createTestPost(String type){
+        List<String> tags = new ArrayList<>();
+        tags.add("개발");
+        tags.add("tag1");
+        tags.add("tag2");
+        tags.add("tag3");
+        tags.add("tag4");
+
+        return new CmdPostAndTagsDTO(type + "Title",  type + "Content", LocalDateTime.now(), 1, 1, tags);
+    }
 
 }

--- a/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
@@ -1,13 +1,16 @@
 package org.triumers.kmsback.post.query.service;
 
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.triumers.kmsback.common.LoggedInUser;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputTypeException;
 import org.triumers.kmsback.employee.command.Application.dto.CmdEmployeeDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdFavoritesDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdPostAndTagsDTO;
@@ -30,88 +33,95 @@ class QryPostServiceTest {
     private final QryPostService qryPostService;
     private final CmdPostService cmdPostService;
 
+    private final LoggedInUser loggedInUser;
+
     @Autowired
-    QryPostServiceTest(QryPostService qryPostService, CmdPostService cmdPostService) {
+    QryPostServiceTest(QryPostService qryPostService, CmdPostService cmdPostService, LoggedInUser loggedInUser) {
         this.qryPostService = qryPostService;
         this.cmdPostService = cmdPostService;
+        this.loggedInUser = loggedInUser;
     }
 
-//    @Test
-//    @DisplayName("tab 게시글 리스트 조회")
-//    void findPostListByTab() throws NotLoginException {
-//
-//        registPost();
-//
-//        PageRequest pageRequest = PageRequest.of(0, 10);
-//
-//        QryRequestPost request = new QryRequestPost(1, null);
-//
-//        Page<QryPostAndTagsDTO> postList = qryPostService.findPostListByTab(request, pageRequest);
-//
-//        assertFalse(postList.isEmpty());
-//    }
-//
-//    @Test
-//    @DisplayName("단일 게시글 조회")
-//    void findPostById() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO post = registPost();
-//        QryPostAndTagsDTO selectedPost = qryPostService.findPostById(post.getId());
-//
-//        assertThat(selectedPost.getId()).isNotNull();
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 히스토리 조회")
-//    void findHistoryListByOriginId() throws NotLoginException {
-//
-//        int originId = modifyPost();
-//        List<QryPostAndTagsDTO> history = qryPostService.findHistoryListByOriginId(originId);
-//
-//        assertFalse(history.isEmpty());
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 좋아요 리스트 조회")
-//    void findLikeListByPostId() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO post = registPost();
-//        CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, post.getId());
-//        cmdPostService.favoritePost(favorite);
-//
-//        List<CmdEmployeeDTO> likeList = qryPostService.findLikeListByPostId(post.getId());
-//
-//        assertThat(likeList).isNotNull();
-//    }
-//
-//    private CmdPostAndTagsDTO registPost() throws NotLoginException {
-//
-//        CmdPostAndTagsDTO post = createTestPost();
-//
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(post);
-//
-//        return  savedPost;
-//    }
-//
-//    private Integer modifyPost() throws NotLoginException {
-//        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
-//
-//        CmdPostAndTagsDTO modifyPost = createTestPost();
-//        modifyPost.setOriginId(savedPost.getId());
-//
-//        cmdPostService.modifyPost(modifyPost);
-//
-//        return modifyPost.getOriginId();
-//    }
-//
-//    private CmdPostAndTagsDTO createTestPost(){
-//        List<String> tags = new ArrayList<>();
-//        tags.add("개발");
-//        tags.add("tag1");
-//        tags.add("tag2");
-//        tags.add("tag3");
-//        tags.add("tag4");
-//
-//        return new CmdPostAndTagsDTO("newTitle", "newContent", LocalDateTime.now(), 1, 1, tags);
-//    }
+    @BeforeEach
+    void loginSetting() throws WrongInputTypeException {
+        loggedInUser.setting();
+    }
+    @Test
+    @DisplayName("tab 게시글 리스트 조회")
+    void findPostListByTab() throws NotLoginException {
+
+        registPost();
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        QryRequestPost request = new QryRequestPost(1, null);
+
+        Page<QryPostAndTagsDTO> postList = qryPostService.findPostListByTab(request, pageRequest);
+
+        assertFalse(postList.isEmpty());
+    }
+
+    @Test
+    @DisplayName("단일 게시글 조회")
+    void findPostById() throws NotLoginException {
+
+        CmdPostAndTagsDTO post = registPost();
+        QryPostAndTagsDTO selectedPost = qryPostService.findPostById(post.getId());
+
+        assertThat(selectedPost.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 히스토리 조회")
+    void findHistoryListByOriginId() throws NotLoginException {
+
+        int originId = modifyPost();
+        List<QryPostAndTagsDTO> history = qryPostService.findHistoryListByOriginId(originId);
+
+        assertFalse(history.isEmpty());
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 리스트 조회")
+    void findLikeListByPostId() throws NotLoginException {
+
+        CmdPostAndTagsDTO post = registPost();
+        CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, post.getId());
+        cmdPostService.favoritePost(favorite);
+
+        List<CmdEmployeeDTO> likeList = qryPostService.findLikeListByPostId(post.getId());
+
+        assertThat(likeList).isNotNull();
+    }
+
+    private CmdPostAndTagsDTO registPost() throws NotLoginException {
+
+        CmdPostAndTagsDTO post = createTestPost();
+
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(post);
+
+        return  savedPost;
+    }
+
+    private Integer modifyPost() throws NotLoginException {
+        CmdPostAndTagsDTO savedPost = cmdPostService.registPost(createTestPost());
+
+        CmdPostAndTagsDTO modifyPost = createTestPost();
+        modifyPost.setOriginId(savedPost.getId());
+
+        cmdPostService.modifyPost(modifyPost);
+
+        return modifyPost.getOriginId();
+    }
+
+    private CmdPostAndTagsDTO createTestPost(){
+        List<String> tags = new ArrayList<>();
+        tags.add("개발");
+        tags.add("tag1");
+        tags.add("tag2");
+        tags.add("tag3");
+        tags.add("tag4");
+
+        return new CmdPostAndTagsDTO("newTitle", "newContent", LocalDateTime.now(), 1, 1, tags);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [x] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/post -> dev

### 변경 사항
- 권한 확인 함수에서 authorId 받아오는 부분 오류 수정
- 위키가 아닌 일반 게시글(모집/강연/컨퍼런스 등) 저장 및 수정을 위해 id 추가

### 테스트 결과
- 전체 테스트 완료 후 통과하였습니다.

### 참고사항
- 일반 게시글의 경우, 히스토리를 저장할 필요가 없으므로 새롭게 저장이 아닌 기존 게시글 업데이트 될 수 있도록 수정