### PR TITLE
[Feature] 자신의 권한 이하 계정 비밀번호 초기화 기능 구현

### DIFF
--- a/src/main/java/org/triumers/kmsback/user/command/Application/controller/ManagerController.java
+++ b/src/main/java/org/triumers/kmsback/user/command/Application/controller/ManagerController.java
@@ -69,4 +69,22 @@ public class ManagerController {
                     new CmdResponseMessageVO(e.getMessage()));
         }
     }
+
+    @PostMapping("/edit/password")
+    public ResponseEntity<CmdResponseMessageVO> initializePassword(@Valid @RequestBody CmdRequestEditUserVO request) {
+        ManageUserDTO targetEmployee = new ManageUserDTO();
+
+        targetEmployee.setEmail(request.getEmail());
+        targetEmployee.setPassword(request.getPassword());
+
+        try {
+            managerService.initializePassword(targetEmployee);
+
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    new CmdResponseMessageVO("비밀번호 초기화 성공"));
+        } catch (NotAuthorizedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    new CmdResponseMessageVO(e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/org/triumers/kmsback/user/command/Application/service/ManagerService.java
+++ b/src/main/java/org/triumers/kmsback/user/command/Application/service/ManagerService.java
@@ -8,4 +8,6 @@ public interface ManagerService {
     void signup(ManageUserDTO userDTO);
 
     void editUserRole(ManageUserDTO userDTO) throws NotAuthorizedException;
+
+    void initializePassword(ManageUserDTO userDTO) throws NotAuthorizedException;
 }

--- a/src/main/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceImpl.java
@@ -67,6 +67,17 @@ public class ManagerServiceImpl implements ManagerService {
         employeeRepository.save(employee);
     }
 
+    @Override
+    public void initializePassword(ManageUserDTO userDTO) throws NotAuthorizedException {
+        Employee employee = employeeRepository.findByEmail(userDTO.getEmail());
+
+        // 변경할 대상 권한이 자신의 권한이하인지 검증
+        validateRole(employee);
+
+        employee.setPassword(passwordEncoder(userDTO.getPassword()));
+        employeeRepository.save(employee);
+    }
+
     private String passwordEncoder(String password) {
         if (password != null) {
             return bCryptPasswordEncoder.encode(password);

--- a/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
@@ -140,6 +140,24 @@ class ManagerServiceTest {
                 newPassword, employeeRepository.findByEmail(TestUserInfo.EMAIL).getPassword()));
     }
 
+    @DisplayName("Default 비밀번호 초기화 테스트")
+    @Test
+    void initializeDefaultPasswordTest() {
+
+        // given
+        addUserForTest();
+        ManageUserDTO targetUser = new ManageUserDTO();
+        targetUser.setEmail(TestUserInfo.EMAIL);
+
+        // when
+        loggedInUser.settingHrManager();
+        assertDoesNotThrow(() -> managerService.initializePassword(targetUser));
+
+        // then
+        assertTrue(bCryptPasswordEncoder.matches(
+                DEFAULT_PASSWORD, employeeRepository.findByEmail(TestUserInfo.EMAIL).getPassword()));
+    }
+
     private void addUserForTest() {
         ManageUserDTO userDTO = new ManageUserDTO(TestUserInfo.EMAIL, TestUserInfo.PASSWORD, TestUserInfo.NAME, null,
                 TestUserInfo.USER_ROLE, null, null, TestUserInfo.PHONE_NUMBER, 1, 1,

--- a/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
@@ -120,6 +120,26 @@ class ManagerServiceTest {
         assertThrows(NotAuthorizedException.class, () -> managerService.editUserRole(targetUser));
     }
 
+    @DisplayName("지정 비밀번호 초기화 테스트")
+    @Test
+    void initializePasswordTest() {
+
+        // given
+        addUserForTest();
+        ManageUserDTO targetUser = new ManageUserDTO();
+        targetUser.setEmail(TestUserInfo.EMAIL);
+        String newPassword = "newPass123";
+        targetUser.setPassword(newPassword);
+
+        // when
+        loggedInUser.settingHrManager();
+        assertDoesNotThrow(() -> managerService.initializePassword(targetUser));
+
+        // then
+        assertTrue(bCryptPasswordEncoder.matches(
+                newPassword, employeeRepository.findByEmail(TestUserInfo.EMAIL).getPassword()));
+    }
+
     private void addUserForTest() {
         ManageUserDTO userDTO = new ManageUserDTO(TestUserInfo.EMAIL, TestUserInfo.PASSWORD, TestUserInfo.NAME, null,
                 TestUserInfo.USER_ROLE, null, null, TestUserInfo.PHONE_NUMBER, 1, 1,

--- a/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/user/command/Application/service/ManagerServiceTest.java
@@ -105,7 +105,7 @@ class ManagerServiceTest {
 
     @DisplayName("자신의 권한을 초과하는 유저 권한 수정 예외 테스트")
     @Test
-    void editOverRoleUSerExceptionTest() {
+    void editOverRoleUserExceptionTest() {
 
         // given
         addHrManagerForTest();
@@ -156,6 +156,26 @@ class ManagerServiceTest {
         // then
         assertTrue(bCryptPasswordEncoder.matches(
                 DEFAULT_PASSWORD, employeeRepository.findByEmail(TestUserInfo.EMAIL).getPassword()));
+    }
+
+    @DisplayName("자신의 권한을 초과하는 유저 비밀번호 초기화 예외 테스트")
+    @Test
+    void initializePasswordOverRoleUserExceptionTest() {
+
+        // given
+        addHrManagerForTest();
+        ManageUserDTO targetUser = new ManageUserDTO();
+        targetUser.setEmail(TestUserInfo.HR_MANAGER_EMAIL);
+        String newPassword = "newPass123";
+        targetUser.setPassword(newPassword);
+
+        // when
+        loggedInUser.setting();
+        assertThrows(NotAuthorizedException.class, () -> managerService.initializePassword(targetUser));
+
+        // then
+        assertFalse(bCryptPasswordEncoder.matches(
+                newPassword, employeeRepository.findByEmail(TestUserInfo.HR_MANAGER_EMAIL).getPassword()));
     }
 
     private void addUserForTest() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/manager -> dev

### 변경 사항
자신의 권한 이하인 계정에 대한 비밀번호를 초기화하는 기능이 구현되었습니다.

### 테스트 결과
- [x] 지정 비밀번호 초기화 테스트 통과
- [x] Default 비밀번호 초기화 테스트 통과
- [x] 자신의 권한을 초과하는 유저 비밀번호 초기화 예외 테스트 통과