### PR TITLE
[Feature] 초기 비밀번호 로그인 시 처리 구현

### DIFF
--- a/src/main/java/org/triumers/kmsback/common/config/SecurityConfig.java
+++ b/src/main/java/org/triumers/kmsback/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.triumers.kmsback.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -29,10 +30,13 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
+    private final String defaultPassword;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtUtil jwtUtil) {
+
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtUtil jwtUtil, @Value("${password}") String defaultPassword) {
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
+        this.defaultPassword = defaultPassword;
     }
 
     @Bean
@@ -100,7 +104,7 @@ public class SecurityConfig {
         http.addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
 
         // 로그인 필터
-        http.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil),
+        http.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, defaultPassword, bCryptPasswordEncoder()),
                 UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정


### PR DESCRIPTION
초기 비밀번호로 로그인 시 HTTP 상태 코드 307을 반환하여 비밀번호를 변경할 수 있도록 구현했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/auth -> dev

### 변경 사항
초기 비밀번호로 로그인 시 307을 반환하며 비밀번호를 변경할 수 있도록 유도하는 기능이 추가되었습니다.

### 테스트 결과
![image](https://github.com/Triumers/KMS-Back/assets/112872644/2d282dc4-6fe4-4792-a88b-a004349165b7)
