### PR TITLE
[Feature] 게시글 ID로 퀴즈 조회

### DIFF
--- a/src/main/java/org/triumers/kmsback/quiz/query/controller/QryQuizController.java
+++ b/src/main/java/org/triumers/kmsback/quiz/query/controller/QryQuizController.java
@@ -33,4 +33,11 @@ public class QryQuizController {
         QryQuizDTO quizDTO = qryQuizService.findQuizById(id);
         return ResponseEntity.ok(quizDTO);
     }
+
+    /* 설명. 게시글 ID로 퀴즈 문제, 정답, 해설, 참조 게시글 조회 */
+    @GetMapping("/exist")
+    public ResponseEntity<QryQuizDTO> findQuizByPostId(@RequestParam int postId) {
+        QryQuizDTO quizDTO = qryQuizService.findQuizByPostId(postId);
+        return ResponseEntity.ok(quizDTO);
+    }
 }

--- a/src/main/java/org/triumers/kmsback/quiz/query/repository/QuizMapper.java
+++ b/src/main/java/org/triumers/kmsback/quiz/query/repository/QuizMapper.java
@@ -11,4 +11,6 @@ public interface QuizMapper {
     List<QryQuiz> findQuizByStatus(boolean status);
 
     QryQuiz findQuizById(int id);
+
+    QryQuiz findQuizByPostId(int postId);
 }

--- a/src/main/java/org/triumers/kmsback/quiz/query/service/QryQuizService.java
+++ b/src/main/java/org/triumers/kmsback/quiz/query/service/QryQuizService.java
@@ -9,4 +9,6 @@ public interface QryQuizService {
     List<QryQuizDTO> findQuizByStatus(boolean status);
 
     QryQuizDTO findQuizById(int id);
+
+    QryQuizDTO findQuizByPostId(int postId);
 }

--- a/src/main/java/org/triumers/kmsback/quiz/query/service/QryQuizServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/quiz/query/service/QryQuizServiceImpl.java
@@ -58,4 +58,20 @@ public class QryQuizServiceImpl implements QryQuizService {
         return qryQuizDTO;
     }
 
+    @Override
+    public QryQuizDTO findQuizByPostId(int postId) {
+        QryQuiz qryQuiz = quizMapper.findQuizByPostId(postId);
+        QryQuizDTO qryQuizDTO = new QryQuizDTO();
+        qryQuizDTO.setId(qryQuiz.getId());
+        qryQuizDTO.setContent(qryQuiz.getContent());
+        qryQuizDTO.setAnswer(qryQuiz.getAnswer());
+        qryQuizDTO.setCommentary(qryQuiz.getCommentary());
+        qryQuizDTO.setStatus(qryQuiz.isStatus());
+        qryQuizDTO.setQuestionerId(qryQuiz.getQuestionerId());
+        qryQuizDTO.setPostId(qryQuiz.getPostId());
+        qryQuizDTO.setTapId(qryQuiz.getTapId());
+
+        return qryQuizDTO;
+    }
+
 }

--- a/src/main/resources/org/triumers/kmsback/quiz/query/repository/QuizMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/quiz/query/repository/QuizMapper.xml
@@ -43,4 +43,18 @@
          WHERE ID = #{id}
     </select>
 
+    <select id="findQuizByPostId" resultMap="quizResultMap" parameterType="org.triumers.kmsback.quiz.query.aggregate.entity.QryQuiz">
+        SELECT
+               ID
+             , CONTENT
+             , ANSWER
+             , COMMENTARY
+             , STATUS
+             , QUESTIONER_ID
+             , POST_ID
+             , TAB_ID
+          FROM tbl_quiz
+         WHERE POST_ID = #{postId}
+    </select>
+
 </mapper>

--- a/src/test/java/org/triumers/kmsback/quiz/query/service/QryQuizServiceImplTest.java
+++ b/src/test/java/org/triumers/kmsback/quiz/query/service/QryQuizServiceImplTest.java
@@ -33,4 +33,11 @@ class QryQuizServiceImplTest {
         QryQuizDTO qryQuizDTO = qryQuizService.findQuizById(1);
         assertNotNull(qryQuizDTO);
     }
+
+    @DisplayName("게시글 ID로 퀴즈 조회")
+    @Test
+    void findQuizByPostId() {
+        QryQuizDTO qryQuizDTO = qryQuizService.findQuizByPostId(1);
+        assertNotNull(qryQuizDTO);
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 및 구조 개선

### 반영 브랜치
ex) feat/quiz -> dev

### 변경 사항
게시글 ID로 퀴즈 조회하여 게시글에 할당된 퀴즈가 있는 경우에만 불러올 수 있도록 구현하였습니다.

### 테스트 결과
테스트 코드 정상 동작 확인되었습니다. 