### PR TITLE
[Refactor] 결재 다중 조회, 취소된 결재 조회 구현 및 페이징 처리

### DIFF
--- a/src/main/java/org/triumers/kmsback/approval/command/Application/controller/CmdRequestApprovalController.java
+++ b/src/main/java/org/triumers/kmsback/approval/command/Application/controller/CmdRequestApprovalController.java
@@ -9,6 +9,8 @@ import org.triumers.kmsback.approval.command.Application.service.CmdApprovalType
 import org.triumers.kmsback.approval.command.Application.service.CmdRequestApprovalService;
 import org.triumers.kmsback.common.exception.NotLoginException;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/approval")
 public class CmdRequestApprovalController {
@@ -65,8 +67,9 @@ public class CmdRequestApprovalController {
     }
 
     @PostMapping("/received/{requestApprovalId}/addApprover")
-    public ResponseEntity<String> addApproverToRequestApproval(@PathVariable int requestApprovalId, @RequestParam int newApproverId) {
+    public ResponseEntity<String> addApproverToRequestApproval(@PathVariable int requestApprovalId, @RequestBody Map<String, Integer> requestBody) {
         try {
+            int newApproverId = requestBody.get("newApproverId");
             cmdRequestApprovalService.addApproverToRequestApproval(requestApprovalId, newApproverId);
             return ResponseEntity.ok("Approver added successfully");
         } catch (Exception e) {

--- a/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
@@ -31,29 +31,29 @@ public class QryRequestApprovalController {
         return qryRequestApprovalService.findById(approvalId);
     }
 
-    // 본인이 요청한 결재 전체 조회(페이징 처리)
-    @GetMapping
-    public List<QryRequestApprovalInfoDTO> findAll(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findAll(page, size);
+    // 본인이 요청한 결재 전체/유형별/기간별/상태별/검색 조회
+    @GetMapping("/search")
+    public List<QryRequestApprovalInfoDTO> findQryRequestApprovalInfo(
+            @RequestParam(value = "typeId", required = false) Integer typeId,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) throws NotLoginException, WrongInputValueException {
+        return qryRequestApprovalService.findQryRequestApprovalInfo(
+                typeId,
+                startDate,
+                endDate,
+                keyword,
+                status,
+                page,
+                size
+        );
     }
 
-    // 본인이 요청한 결재 유형별 조회(페이징 처리)
-    @GetMapping("/type/{typeId}")
-    public List<QryRequestApprovalInfoDTO> findByType(@PathVariable("typeId") int typeId,
-                                                      @RequestParam(value = "page", defaultValue = "1") int page,
-                                                      @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findByType(typeId, page, size);
-    }
 
-    // 본인이 요청한 결재 기간별 조회(페이징 처리)
-    @GetMapping("/date-range")
-    public List<QryRequestApprovalInfoDTO> findByDateRange(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-                                                           @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
-                                                           @RequestParam(value = "page", defaultValue = "1") int page,
-                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findByDateRange(startDate, endDate, page, size);
-    }
 
     // 본인이 요청받은 결재 단일 조회
     @GetMapping("/received/{requestApprovalId}")
@@ -85,25 +85,7 @@ public class QryRequestApprovalController {
         return qryRequestApprovalService.findReceivedByDateRange(startDate, endDate, page, size);
     }
 
-    // 본인이 요청한 결재 내용 검색
-    @GetMapping("/search")
-    public List<QryRequestApprovalInfoDTO> findByContent(
-            @RequestParam("keyword") String keyword,
-            @RequestParam(value = "page", defaultValue = "1") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findByContent(keyword, page, size);
-    }
 
-    // 본인이 요청한 결재 승인 상태별 조회
-    @GetMapping("/status/{status}")
-    public List<QryRequestApprovalInfoDTO> findByStatus(
-            @PathVariable("status") String status,
-            @RequestParam(value = "page", defaultValue = "1") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findByStatus(status, page, size);
-    }
 
     // 본인이 요청받은 결재 내용 검색
     @GetMapping("/received/search")

--- a/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
@@ -9,6 +9,7 @@ import org.triumers.kmsback.approval.query.dto.QryRequestApprovalWithEmployeeDTO
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
 import org.triumers.kmsback.approval.query.service.QryRequestApprovalService;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,14 +27,14 @@ public class QryRequestApprovalController {
 
     // 본인이 요청한 결재 단일 조회
     @GetMapping("/{approvalId}")
-    public QryRequestApprovalWithEmployeeDTO findById(@PathVariable("approvalId") int approvalId) throws NotLoginException {
+    public QryRequestApprovalWithEmployeeDTO findById(@PathVariable("approvalId") int approvalId) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findById(approvalId);
     }
 
     // 본인이 요청한 결재 전체 조회(페이징 처리)
     @GetMapping
     public List<QryRequestApprovalInfoDTO> findAll(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findAll(page, size);
     }
 
@@ -41,7 +42,7 @@ public class QryRequestApprovalController {
     @GetMapping("/type/{typeId}")
     public List<QryRequestApprovalInfoDTO> findByType(@PathVariable("typeId") int typeId,
                                                       @RequestParam(value = "page", defaultValue = "1") int page,
-                                                      @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                      @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findByType(typeId, page, size);
     }
 
@@ -50,20 +51,20 @@ public class QryRequestApprovalController {
     public List<QryRequestApprovalInfoDTO> findByDateRange(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
                                                            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
                                                            @RequestParam(value = "page", defaultValue = "1") int page,
-                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findByDateRange(startDate, endDate, page, size);
     }
 
     // 본인이 요청받은 결재 단일 조회
     @GetMapping("/received/{requestApprovalId}")
-    public QryRequestApprovalWithEmployeeDTO findReceivedById(@PathVariable("requestApprovalId") int requestApprovalId) throws NotLoginException {
+    public QryRequestApprovalWithEmployeeDTO findReceivedById(@PathVariable("requestApprovalId") int requestApprovalId) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedById(requestApprovalId);
     }
 
     // 본인이 요청받은 결재 전체 조회(페이징 처리)
     @GetMapping("/received")
     public List<QryRequestApprovalInfoDTO> findAllReceived(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findAllReceived(page, size);
     }
 
@@ -71,7 +72,7 @@ public class QryRequestApprovalController {
     @GetMapping("/received/type/{typeId}")
     public List<QryRequestApprovalInfoDTO> findReceivedByType(@PathVariable("typeId") int typeId,
                                                               @RequestParam(value = "page", defaultValue = "1") int page,
-                                                              @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                              @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedByType(typeId, page, size);
     }
 
@@ -80,7 +81,7 @@ public class QryRequestApprovalController {
     public List<QryRequestApprovalInfoDTO> findReceivedByDateRange(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
                                                                    @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
                                                                    @RequestParam(value = "page", defaultValue = "1") int page,
-                                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException {
+                                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedByDateRange(startDate, endDate, page, size);
     }
 
@@ -90,7 +91,7 @@ public class QryRequestApprovalController {
             @RequestParam("keyword") String keyword,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException {
+    ) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findByContent(keyword, page, size);
     }
 
@@ -100,7 +101,7 @@ public class QryRequestApprovalController {
             @PathVariable("status") String status,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException {
+    ) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findByStatus(status, page, size);
     }
 
@@ -110,7 +111,7 @@ public class QryRequestApprovalController {
             @RequestParam("keyword") String keyword,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException {
+    ) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedByContent(keyword, page, size);
     }
 
@@ -120,7 +121,7 @@ public class QryRequestApprovalController {
             @PathVariable("status") String status,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException {
+    ) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedByStatus(status, page, size);
     }
 

--- a/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
@@ -39,6 +39,7 @@ public class QryRequestApprovalController {
             @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "isCanceled", required = false) Boolean isCanceled,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) throws NotLoginException, WrongInputValueException {
@@ -48,6 +49,7 @@ public class QryRequestApprovalController {
                 endDate,
                 keyword,
                 status,
+                isCanceled,
                 page,
                 size
         );
@@ -67,6 +69,7 @@ public class QryRequestApprovalController {
             @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "isCanceled", required = false) Boolean isCanceled,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) throws NotLoginException, WrongInputValueException {
@@ -76,6 +79,7 @@ public class QryRequestApprovalController {
                 endDate,
                 keyword,
                 status,
+                isCanceled,
                 page,
                 size
         );

--- a/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/controller/QryRequestApprovalController.java
@@ -53,58 +53,32 @@ public class QryRequestApprovalController {
         );
     }
 
-
-
     // 본인이 요청받은 결재 단일 조회
     @GetMapping("/received/{requestApprovalId}")
     public QryRequestApprovalWithEmployeeDTO findReceivedById(@PathVariable("requestApprovalId") int requestApprovalId) throws NotLoginException, WrongInputValueException {
         return qryRequestApprovalService.findReceivedById(requestApprovalId);
     }
 
-    // 본인이 요청받은 결재 전체 조회(페이징 처리)
-    @GetMapping("/received")
-    public List<QryRequestApprovalInfoDTO> findAllReceived(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                           @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findAllReceived(page, size);
-    }
-
-    // 본인이 요청받은 결재 유형별 조회(페이징 처리)
-    @GetMapping("/received/type/{typeId}")
-    public List<QryRequestApprovalInfoDTO> findReceivedByType(@PathVariable("typeId") int typeId,
-                                                              @RequestParam(value = "page", defaultValue = "1") int page,
-                                                              @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findReceivedByType(typeId, page, size);
-    }
-
-    // 본인이 요청받은 결재 기간별 조회(페이징 처리)
-    @GetMapping("/received/date-range")
-    public List<QryRequestApprovalInfoDTO> findReceivedByDateRange(@RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-                                                                   @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
-                                                                   @RequestParam(value = "page", defaultValue = "1") int page,
-                                                                   @RequestParam(value = "size", defaultValue = "10") int size) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findReceivedByDateRange(startDate, endDate, page, size);
-    }
-
-
-
-    // 본인이 요청받은 결재 내용 검색
+    // 본인이 요청받은 결재 전체/유형별/기간별/상태별/검색 조회
     @GetMapping("/received/search")
-    public List<QryRequestApprovalInfoDTO> findReceivedByContent(
-            @RequestParam("keyword") String keyword,
+    public List<QryRequestApprovalInfoDTO> findReceivedQryRequestApprovalInfo(
+            @RequestParam(value = "typeId", required = false) Integer typeId,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "status", required = false) String status,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findReceivedByContent(keyword, page, size);
-    }
-
-    // 본인이 요청받은 결재 승인 상태별 조회
-    @GetMapping("/received/status/{status}")
-    public List<QryRequestApprovalInfoDTO> findReceivedByStatus(
-            @PathVariable("status") String status,
-            @RequestParam(value = "page", defaultValue = "1") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size
-    ) throws NotLoginException, WrongInputValueException {
-        return qryRequestApprovalService.findReceivedByStatus(status, page, size);
+        return qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                typeId,
+                startDate,
+                endDate,
+                keyword,
+                status,
+                page,
+                size
+        );
     }
 
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/dto/QryRequestApprovalInfoDTO.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/dto/QryRequestApprovalInfoDTO.java
@@ -29,4 +29,7 @@ public class QryRequestApprovalInfoDTO {
     private int requesterId;
     private int typeId;
     private String type;
+
+    // 전체 결과 개수
+    private int totalCount;
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/dto/QryRequestApprovalWithEmployeeDTO.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/dto/QryRequestApprovalWithEmployeeDTO.java
@@ -1,7 +1,7 @@
 package org.triumers.kmsback.approval.query.dto;
 
 import lombok.*;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -10,6 +10,6 @@ import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
 @ToString
 public class QryRequestApprovalWithEmployeeDTO {
     private QryRequestApprovalInfoDTO approvalInfo;
-    private CmdEmployeeDTO requester;
-    private CmdEmployeeDTO approver;
+    private QryEmployeeDTO requester;
+    private QryEmployeeDTO approver;
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
@@ -23,11 +23,15 @@ public interface QryRequestApprovalMapper {
             @Param("limit") int limit
     );
 
-
     QryRequestApprovalInfoDTO findReceivedById(@Param("approverId") int employeeId, @Param("requestApprovalId") int requestApprovalId);
-    List<QryRequestApprovalInfoDTO> findAllReceived(@Param("approverId") int employeeId, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findReceivedByType(@Param("approverId") int employeeId, @Param("typeId") int typeId, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findReceivedByDateRange(@Param("approverId") int employeeId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findReceivedByContent(@Param("approverId") int approverId, @Param("keyword") String keyword, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findReceivedByStatus(@Param("approverId") int approverId, @Param("status") String status, @Param("offset") int offset, @Param("limit") int limit);
+    List<QryRequestApprovalInfoDTO> findReceivedQryRequestApprovalInfo(
+            @Param("approverId") int approverId,
+            @Param("typeId") @Nullable Integer typeId,
+            @Param("startDate") @Nullable LocalDateTime startDate,
+            @Param("endDate") @Nullable LocalDateTime endDate,
+            @Param("keyword") @Nullable String keyword,
+            @Param("status") @Nullable String status,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
@@ -19,6 +19,7 @@ public interface QryRequestApprovalMapper {
             @Param("endDate") @Nullable LocalDateTime endDate,
             @Param("keyword") @Nullable String keyword,
             @Param("status") @Nullable String status,
+            @Param("isCanceled") @Nullable Boolean isCanceled,
             @Param("offset") int offset,
             @Param("limit") int limit
     );
@@ -31,6 +32,7 @@ public interface QryRequestApprovalMapper {
             @Param("endDate") @Nullable LocalDateTime endDate,
             @Param("keyword") @Nullable String keyword,
             @Param("status") @Nullable String status,
+            @Param("isCanceled") @Nullable Boolean isCanceled,
             @Param("offset") int offset,
             @Param("limit") int limit
     );

--- a/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.java
@@ -1,5 +1,6 @@
 package org.triumers.kmsback.approval.query.repository;
 
+import jakarta.annotation.Nullable;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
@@ -9,18 +10,24 @@ import java.util.List;
 
 @Mapper
 public interface QryRequestApprovalMapper {
+
     QryRequestApprovalInfoDTO findById(@Param("requesterId") int employeeId, @Param("approvalId") int approvalId);
-    List<QryRequestApprovalInfoDTO> findAll(@Param("requesterId") int employeeId, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findByType(@Param("requesterId") int employeeId, @Param("typeId") int typeId, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findByDateRange(@Param("requesterId") int employeeId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("offset") int offset, @Param("limit") int limit);
+    List<QryRequestApprovalInfoDTO> findQryRequestApprovalInfo(
+            @Param("requesterId") int requesterId,
+            @Param("typeId") @Nullable Integer typeId,
+            @Param("startDate") @Nullable LocalDateTime startDate,
+            @Param("endDate") @Nullable LocalDateTime endDate,
+            @Param("keyword") @Nullable String keyword,
+            @Param("status") @Nullable String status,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
 
     QryRequestApprovalInfoDTO findReceivedById(@Param("approverId") int employeeId, @Param("requestApprovalId") int requestApprovalId);
     List<QryRequestApprovalInfoDTO> findAllReceived(@Param("approverId") int employeeId, @Param("offset") int offset, @Param("limit") int limit);
     List<QryRequestApprovalInfoDTO> findReceivedByType(@Param("approverId") int employeeId, @Param("typeId") int typeId, @Param("offset") int offset, @Param("limit") int limit);
     List<QryRequestApprovalInfoDTO> findReceivedByDateRange(@Param("approverId") int employeeId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("offset") int offset, @Param("limit") int limit);
-
-    List<QryRequestApprovalInfoDTO> findByContent(@Param("requesterId") int requesterId, @Param("keyword") String keyword, @Param("offset") int offset, @Param("limit") int limit);
-    List<QryRequestApprovalInfoDTO> findByStatus(@Param("requesterId") int requesterId, @Param("status") String status, @Param("offset") int offset, @Param("limit") int limit);
     List<QryRequestApprovalInfoDTO> findReceivedByContent(@Param("approverId") int approverId, @Param("keyword") String keyword, @Param("offset") int offset, @Param("limit") int limit);
     List<QryRequestApprovalInfoDTO> findReceivedByStatus(@Param("approverId") int approverId, @Param("status") String status, @Param("offset") int offset, @Param("limit") int limit);
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
@@ -20,6 +20,7 @@ public interface QryRequestApprovalService {
             @Nullable LocalDateTime endDate,
             @Nullable String keyword,
             @Nullable String status,
+            @Nullable Boolean isCanceled,
             int page,
             int size
     ) throws NotLoginException, WrongInputValueException;
@@ -36,6 +37,7 @@ public interface QryRequestApprovalService {
             @Nullable LocalDateTime endDate,
             @Nullable String keyword,
             @Nullable String status,
+            @Nullable Boolean isCanceled,
             int page,
             int size
     ) throws NotLoginException, WrongInputValueException;

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
@@ -3,44 +3,45 @@ package org.triumers.kmsback.approval.query.service;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalWithEmployeeDTO;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface QryRequestApprovalService {
     // 본인이 요청한 결재 단일 조회
-    QryRequestApprovalWithEmployeeDTO findById(int approvalId) throws NotLoginException;
+    QryRequestApprovalWithEmployeeDTO findById(int approvalId) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청한 결재 전체 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청한 결재 유형별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청한 결재 기간별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청한 결재 내용 검색
-    List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청한 결재 승인 상태별 조회
-    List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 단일 조회
-    QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException;
+    QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 전체 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 유형별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 기간별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 내용 검색
-    List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 승인 상태별 조회
-    List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException;
+    List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException;
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
@@ -1,5 +1,6 @@
 package org.triumers.kmsback.approval.query.service;
 
+import jakarta.annotation.Nullable;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalWithEmployeeDTO;
 import org.triumers.kmsback.common.exception.NotLoginException;
@@ -12,20 +13,18 @@ public interface QryRequestApprovalService {
     // 본인이 요청한 결재 단일 조회
     QryRequestApprovalWithEmployeeDTO findById(int approvalId) throws NotLoginException, WrongInputValueException;
 
-    // 본인이 요청한 결재 전체 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException, WrongInputValueException;
+    // 본인이 요청한 결재 전체/유형별/기간별/상태별/검색 조회
+    List<QryRequestApprovalInfoDTO> findQryRequestApprovalInfo(
+            @Nullable Integer typeId,
+            @Nullable LocalDateTime startDate,
+            @Nullable LocalDateTime endDate,
+            @Nullable String keyword,
+            @Nullable String status,
+            int page,
+            int size
+    ) throws NotLoginException, WrongInputValueException;
 
-    // 본인이 요청한 결재 유형별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException;
 
-    // 본인이 요청한 결재 기간별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청한 결재 내용 검색
-    List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청한 결재 승인 상태별 조회
-    List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException;
 
     // 본인이 요청받은 결재 단일 조회
     QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException;

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalService.java
@@ -29,18 +29,14 @@ public interface QryRequestApprovalService {
     // 본인이 요청받은 결재 단일 조회
     QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException;
 
-    // 본인이 요청받은 결재 전체 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청받은 결재 유형별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청받은 결재 기간별 조회(페이징 처리)
-    List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청받은 결재 내용 검색
-    List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException;
-
-    // 본인이 요청받은 결재 승인 상태별 조회
-    List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException;
+    // 본인이 요청받은 결재 전체/유형별/기간별/상태별/검색 조회
+    List<QryRequestApprovalInfoDTO> findReceivedQryRequestApprovalInfo(
+            @Nullable Integer typeId,
+            @Nullable LocalDateTime startDate,
+            @Nullable LocalDateTime endDate,
+            @Nullable String keyword,
+            @Nullable String status,
+            int page,
+            int size
+    ) throws NotLoginException, WrongInputValueException;
 }

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -47,6 +47,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
             @Nullable LocalDateTime endDate,
             @Nullable String keyword,
             @Nullable String status,
+            @Nullable Boolean isCanceled,
             int page,
             int size
     ) throws NotLoginException, WrongInputValueException {
@@ -61,6 +62,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
                 endDate,
                 keyword,
                 status,
+                isCanceled,
                 offset,
                 limit
         );
@@ -91,6 +93,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
             @Nullable LocalDateTime endDate,
             @Nullable String keyword,
             @Nullable String status,
+            @Nullable Boolean isCanceled,
             int page,
             int size
     ) throws NotLoginException, WrongInputValueException {
@@ -105,6 +108,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
                 endDate,
                 keyword,
                 status,
+                isCanceled,
                 offset,
                 limit
         );

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -72,10 +72,6 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
     }
 
-
-
-
-
     // 본인이 요청받은 결재 단일 조회
     public QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
@@ -87,74 +83,33 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalWithEmployeeDTO(approvalInfo);
     }
 
-    // 본인이 요청받은 결재 전체 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException, WrongInputValueException {
+    // 본인이 요청받은 결재 전체/유형별/기간별/상태별/검색 조회
+    public List<QryRequestApprovalInfoDTO> findReceivedQryRequestApprovalInfo(
+            @Nullable Integer typeId,
+            @Nullable LocalDateTime startDate,
+            @Nullable LocalDateTime endDate,
+            @Nullable String keyword,
+            @Nullable String status,
+            int page,
+            int size
+    ) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findAllReceived(approverId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedQryRequestApprovalInfo(
+                approverId,
+                typeId,
+                startDate,
+                endDate,
+                keyword,
+                status,
+                offset,
+                limit
+        );
+
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for approverId: " + approverId);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
-
-    // 본인이 요청받은 결재 유형별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException {
-        int approverId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByType(approverId, typeId, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for approverId: " + approverId + ", typeId: " + typeId);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
-
-    // 본인이 요청받은 결재 기간별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException {
-        int approverId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByDateRange(approverId, startDate, endDate, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for approverId: " + approverId + " between " + startDate + " and " + endDate);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
-
-
-
-
-    // 본인이 요청받은 결재 내용 검색
-    public List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException {
-        int approverId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByContent(approverId, keyword, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for approverId: " + approverId + ", keyword: " + keyword);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
-
-    // 본인이 요청받은 결재 승인 상태별 조회
-    public List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException {
-        int approverId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByStatus(approverId, status, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for approverId: " + approverId + ", status: " + status);
+            throw new IllegalArgumentException("No approvals found for the given criteria.");
         }
 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -72,6 +72,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
     }
 
+
     // 본인이 요청받은 결재 단일 조회
     public QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -59,7 +59,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByType(typeId, requesterId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByType(requesterId, typeId, offset, limit);
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
             throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + ", typeId: " + typeId);
         }
@@ -112,7 +112,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByType(typeId, approverId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByType(approverId, typeId, offset, limit);
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
             throw new IllegalArgumentException("No approvals found for approverId: " + approverId + ", typeId: " + typeId);
         }

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -6,9 +6,10 @@ import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalWithEmployeeDTO;
 import org.triumers.kmsback.approval.query.repository.QryRequestApprovalMapper;
 import org.triumers.kmsback.common.exception.NotLoginException;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.user.command.Application.service.AuthService;
-import org.triumers.kmsback.user.command.Application.service.CmdEmployeeService;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
+import org.triumers.kmsback.user.query.service.QryEmployeeService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,18 +18,18 @@ import java.util.List;
 public class QryRequestApprovalServiceImpl implements QryRequestApprovalService {
 
     private final QryRequestApprovalMapper qryRequestApprovalMapper;
-    private final CmdEmployeeService cmdEmployeeService;
+    private final QryEmployeeService qryEmployeeService;
     private final AuthService authService;
 
     @Autowired
-    public QryRequestApprovalServiceImpl(QryRequestApprovalMapper qryRequestApprovalMapper, CmdEmployeeService cmdEmployeeService, AuthService authService) {
+    public QryRequestApprovalServiceImpl(QryRequestApprovalMapper qryRequestApprovalMapper, QryEmployeeService qryEmployeeService, AuthService authService) {
         this.qryRequestApprovalMapper = qryRequestApprovalMapper;
-        this.cmdEmployeeService = cmdEmployeeService;
+        this.qryEmployeeService = qryEmployeeService;
         this.authService = authService;
     }
 
     // 본인이 요청한 결재 단일 조회
-    public QryRequestApprovalWithEmployeeDTO findById(int approvalId) throws NotLoginException {
+    public QryRequestApprovalWithEmployeeDTO findById(int approvalId) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         QryRequestApprovalInfoDTO approvalInfo = qryRequestApprovalMapper.findById(requesterId, approvalId);
         if (approvalInfo == null) {
@@ -39,7 +40,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청한 결재 전체 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -53,12 +54,12 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청한 결재 유형별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByType(requesterId, typeId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByType(typeId, requesterId, offset, limit);
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
             throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + ", typeId: " + typeId);
         }
@@ -67,7 +68,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청한 결재 기간별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -81,7 +82,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 단일 조회
-    public QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException {
+    public QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         QryRequestApprovalInfoDTO approvalInfo = qryRequestApprovalMapper.findReceivedById(approverId, requestApprovalId);
         if (approvalInfo == null) {
@@ -92,7 +93,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 전체 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findAllReceived(int page, int size) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -106,12 +107,12 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 유형별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findReceivedByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByType(approverId, typeId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findReceivedByType(typeId, approverId, offset, limit);
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
             throw new IllegalArgumentException("No approvals found for approverId: " + approverId + ", typeId: " + typeId);
         }
@@ -120,7 +121,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 기간별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findReceivedByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -134,7 +135,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청한 결재 내용 검색
-    public List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -148,7 +149,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청한 결재 승인 상태별 조회
-    public List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -162,7 +163,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 내용 검색
-    public List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -176,7 +177,7 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
     }
 
     // 본인이 요청받은 결재 승인 상태별 조회
-    public List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException {
+    public List<QryRequestApprovalInfoDTO> findReceivedByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException {
         int approverId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
@@ -189,13 +190,13 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
     }
 
-    private QryRequestApprovalWithEmployeeDTO getQryRequestApprovalWithEmployeeDTO(QryRequestApprovalInfoDTO approvalInfo) {
-        CmdEmployeeDTO requester = cmdEmployeeService.findEmployeeById(approvalInfo.getRequesterId());
+    private QryRequestApprovalWithEmployeeDTO getQryRequestApprovalWithEmployeeDTO(QryRequestApprovalInfoDTO approvalInfo) throws WrongInputValueException {
+        QryEmployeeDTO requester = qryEmployeeService.findEmployeeById(approvalInfo.getRequesterId());
         if (requester == null) {
             throw new IllegalArgumentException("Requester not found with id: " + approvalInfo.getRequesterId());
         }
 
-        CmdEmployeeDTO approver = cmdEmployeeService.findEmployeeById(approvalInfo.getApproverId());
+        QryEmployeeDTO approver = qryEmployeeService.findEmployeeById(approvalInfo.getApproverId());
         if (approver == null) {
             throw new IllegalArgumentException("Approver not found with id: " + approvalInfo.getApproverId());
         }
@@ -208,16 +209,16 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return result;
     }
 
-    private List<QryRequestApprovalInfoDTO> getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(List<QryRequestApprovalInfoDTO> approvalInfoDTOS) {
+    private List<QryRequestApprovalInfoDTO> getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(List<QryRequestApprovalInfoDTO> approvalInfoDTOS) throws WrongInputValueException {
         for (QryRequestApprovalInfoDTO approvalInfoDTO : approvalInfoDTOS) {
-            CmdEmployeeDTO requester = cmdEmployeeService.findEmployeeById(approvalInfoDTO.getRequesterId());
+            QryEmployeeDTO requester = qryEmployeeService.findEmployeeById(approvalInfoDTO.getRequesterId());
             if (requester == null) {
                 throw new IllegalArgumentException("Requester not found with id: " + approvalInfoDTO.getRequesterId());
             }
             approvalInfoDTO.setRequesterId(requester.getId());
             approvalInfoDTO.setRequesterName(requester.getName());
 
-            CmdEmployeeDTO approver = cmdEmployeeService.findEmployeeById(approvalInfoDTO.getApproverId());
+            QryEmployeeDTO approver = qryEmployeeService.findEmployeeById(approvalInfoDTO.getApproverId());
             if (approver == null) {
                 throw new IllegalArgumentException("Approver not found with id: " + approvalInfoDTO.getApproverId());
             }

--- a/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImpl.java
@@ -1,5 +1,6 @@
 package org.triumers.kmsback.approval.query.service;
 
+import jakarta.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO;
@@ -39,47 +40,41 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalWithEmployeeDTO(approvalInfo);
     }
 
-    // 본인이 요청한 결재 전체 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findAll(int page, int size) throws NotLoginException, WrongInputValueException {
+    // 본인이 요청한 결재 전체/유형별/기간별/상태별/검색 조회
+    public List<QryRequestApprovalInfoDTO> findQryRequestApprovalInfo(
+            @Nullable Integer typeId,
+            @Nullable LocalDateTime startDate,
+            @Nullable LocalDateTime endDate,
+            @Nullable String keyword,
+            @Nullable String status,
+            int page,
+            int size
+    ) throws NotLoginException, WrongInputValueException {
         int requesterId = authService.whoAmI().getId();
         int offset = (page - 1) * size;
         int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findAll(requesterId, offset, limit);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findQryRequestApprovalInfo(
+                requesterId,
+                typeId,
+                startDate,
+                endDate,
+                keyword,
+                status,
+                offset,
+                limit
+        );
+
         if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId);
+            throw new IllegalArgumentException("No approvals found for the given criteria.");
         }
 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
     }
 
-    // 본인이 요청한 결재 유형별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findByType(int typeId, int page, int size) throws NotLoginException, WrongInputValueException {
-        int requesterId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByType(requesterId, typeId, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + ", typeId: " + typeId);
-        }
 
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
 
-    // 본인이 요청한 결재 기간별 조회(페이징 처리)
-    public List<QryRequestApprovalInfoDTO> findByDateRange(LocalDateTime startDate, LocalDateTime endDate, int page, int size) throws NotLoginException, WrongInputValueException {
-        int requesterId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByDateRange(requesterId, startDate, endDate, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + " between " + startDate + " and " + endDate);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
 
     // 본인이 요청받은 결재 단일 조회
     public QryRequestApprovalWithEmployeeDTO findReceivedById(int requestApprovalId) throws NotLoginException, WrongInputValueException {
@@ -134,33 +129,8 @@ public class QryRequestApprovalServiceImpl implements QryRequestApprovalService 
         return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
     }
 
-    // 본인이 요청한 결재 내용 검색
-    public List<QryRequestApprovalInfoDTO> findByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException {
-        int requesterId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
 
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByContent(requesterId, keyword, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + ", keyword: " + keyword);
-        }
 
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
-
-    // 본인이 요청한 결재 승인 상태별 조회
-    public List<QryRequestApprovalInfoDTO> findByStatus(String status, int page, int size) throws NotLoginException, WrongInputValueException {
-        int requesterId = authService.whoAmI().getId();
-        int offset = (page - 1) * size;
-        int limit = size;
-
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalMapper.findByStatus(requesterId, status, offset, limit);
-        if (approvalInfoDTOS == null || approvalInfoDTOS.isEmpty()) {
-            throw new IllegalArgumentException("No approvals found for requesterId: " + requesterId + ", status: " + status);
-        }
-
-        return getQryRequestApprovalInfoDTOSWithEmployeeIdAndName(approvalInfoDTOS);
-    }
 
     // 본인이 요청받은 결재 내용 검색
     public List<QryRequestApprovalInfoDTO> findReceivedByContent(String keyword, int page, int size) throws NotLoginException, WrongInputValueException {

--- a/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
@@ -48,6 +48,9 @@
         <if test="keyword != null">
             AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
         </if>
+        <if test="isCanceled != null">
+            AND RA.IS_CANCELED = #{isCanceled}
+        </if>
         <if test="status != null">
             AND RA.IS_APPROVED = #{status}
         </if>
@@ -97,6 +100,9 @@
         </if>
         <if test="keyword != null">
             AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        <if test="isCanceled != null">
+            AND RA.IS_CANCELED = #{isCanceled}
         </if>
         <if test="status != null">
             AND RA.IS_APPROVED = #{status}

--- a/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
@@ -20,114 +20,42 @@
           AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID);
     </select>
 
-    <select id="findAll" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
+    <select id="findQryRequestApprovalInfo" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
         SELECT
-            RA.ID AS requestApprovalId,
-            RA.APPROVAL_ORDER AS approvalOrder,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
+        RA.ID AS requestApprovalId,
+        RA.APPROVAL_ORDER AS approvalOrder,
+        RA.IS_CANCELED AS isCanceled,
+        RA.IS_APPROVED AS isApproved,
+        A.ID AS approvalId,
+        A.CONTENT AS content,
+        A.CREATED_AT AS createdAt,
+        T.ID AS typeId,
+        T.TYPE AS type,
+        A.EMPLOYEE_ID AS requesterId,
+        RA.EMPLOYEE_ID AS approverId
         FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
+        JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
+        JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
         WHERE A.EMPLOYEE_ID = #{requesterId}
-          AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-            LIMIT #{offset}, #{limit}
+        AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
+        <if test="typeId != null">
+            AND A.TYPE_ID = #{typeId}
+        </if>
+        <if test="startDate != null and endDate != null">
+            AND A.CREATED_AT BETWEEN #{startDate} AND #{endDate}
+        </if>
+        <if test="keyword != null">
+            AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        <if test="status != null">
+            AND RA.IS_APPROVED = #{status}
+        </if>
+        LIMIT #{offset}, #{limit}
     </select>
 
-    <select id="findByType" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.APPROVAL_ORDER AS approvalOrder,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE A.EMPLOYEE_ID = #{requesterId}
-          AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-          AND A.TYPE_ID = #{typeId}
-            LIMIT #{offset}, #{limit}
-    </select>
 
-    <select id="findByDateRange" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.APPROVAL_ORDER AS approvalOrder,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE A.EMPLOYEE_ID = #{requesterId}
-          AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-          AND A.CREATED_AT BETWEEN #{startDate} AND #{endDate}
-            LIMIT #{offset}, #{limit}
-    </select>
 
-    <select id="findByContent" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.APPROVAL_ORDER AS approvalOrder,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE A.EMPLOYEE_ID = #{requesterId}
-          AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-          AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
-            LIMIT #{offset}, #{limit}
-    </select>
 
-    <select id="findByStatus" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.APPROVAL_ORDER AS approvalOrder,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE A.EMPLOYEE_ID = #{requesterId}
-          AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-          AND RA.IS_APPROVED = #{status}
-            LIMIT #{offset}, #{limit}
-    </select>
 
     <select id="findReceivedById" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
         SELECT

--- a/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
@@ -53,10 +53,6 @@
         LIMIT #{offset}, #{limit}
     </select>
 
-
-
-
-
     <select id="findReceivedById" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
         SELECT
             RA.ID AS requestApprovalId,
@@ -75,102 +71,34 @@
           AND RA.ID = #{requestApprovalId}
     </select>
 
-    <select id="findAllReceived" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
+    <select id="findReceivedQryRequestApprovalInfo" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
         SELECT
-            RA.ID AS requestApprovalId,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
+        RA.ID AS requestApprovalId,
+        RA.IS_CANCELED AS isCanceled,
+        RA.IS_APPROVED AS isApproved,
+        A.ID AS approvalId,
+        A.CONTENT AS content,
+        A.CREATED_AT AS createdAt,
+        T.ID AS typeId,
+        T.TYPE AS type,
+        A.EMPLOYEE_ID AS requesterId,
+        RA.EMPLOYEE_ID AS approverId
         FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
+        JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
+        JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
         WHERE RA.EMPLOYEE_ID = #{approverId}
-            LIMIT #{offset}, #{limit}
-    </select>
-
-    <select id="findReceivedByType" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE RA.EMPLOYEE_ID = #{approverId}
-          AND A.TYPE_ID = #{typeId}
-            LIMIT #{offset}, #{limit}
-    </select>
-
-    <select id="findReceivedByDateRange" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE RA.EMPLOYEE_ID = #{approverId}
-          AND A.CREATED_AT BETWEEN #{startDate} AND #{endDate}
-            LIMIT #{offset}, #{limit}
-    </select>
-
-    <select id="findReceivedByContent" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE RA.EMPLOYEE_ID = #{approverId}
-          AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
-            LIMIT #{offset}, #{limit}
-    </select>
-
-    <select id="findReceivedByStatus" resultType="org.triumers.kmsback.approval.query.dto.QryRequestApprovalInfoDTO">
-        SELECT
-            RA.ID AS requestApprovalId,
-            RA.IS_CANCELED AS isCanceled,
-            RA.IS_APPROVED AS isApproved,
-            A.ID AS approvalId,
-            A.CONTENT AS content,
-            A.CREATED_AT AS createdAt,
-            T.ID AS typeId,
-            T.TYPE AS type,
-            A.EMPLOYEE_ID AS requesterId,
-            RA.EMPLOYEE_ID AS approverId
-        FROM tbl_request_approval RA
-                 JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
-                 JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
-        WHERE RA.EMPLOYEE_ID = #{approverId}
-          AND RA.IS_APPROVED = #{status}
-            LIMIT #{offset}, #{limit}
+        <if test="typeId != null">
+            AND A.TYPE_ID = #{typeId}
+        </if>
+        <if test="startDate != null and endDate != null">
+            AND A.CREATED_AT BETWEEN #{startDate} AND #{endDate}
+        </if>
+        <if test="keyword != null">
+            AND A.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        <if test="status != null">
+            AND RA.IS_APPROVED = #{status}
+        </if>
+        LIMIT #{offset}, #{limit}
     </select>
 </mapper>

--- a/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
@@ -32,7 +32,8 @@
         T.ID AS typeId,
         T.TYPE AS type,
         A.EMPLOYEE_ID AS requesterId,
-        RA.EMPLOYEE_ID AS approverId
+        RA.EMPLOYEE_ID AS approverId,
+        COUNT(*) OVER() AS totalCount
         FROM tbl_request_approval RA
         JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
         JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
@@ -82,7 +83,8 @@
         T.ID AS typeId,
         T.TYPE AS type,
         A.EMPLOYEE_ID AS requesterId,
-        RA.EMPLOYEE_ID AS approverId
+        RA.EMPLOYEE_ID AS approverId,
+        COUNT(*) OVER() AS totalCount
         FROM tbl_request_approval RA
         JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
         JOIN tbl_approval_type T ON A.TYPE_ID = T.ID

--- a/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/approval/query/repository/QryRequestApprovalMapper.xml
@@ -59,7 +59,7 @@
                  JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
         WHERE A.EMPLOYEE_ID = #{requesterId}
           AND RA.APPROVAL_ORDER = (SELECT MAX(APPROVAL_ORDER) FROM tbl_request_approval WHERE APPROVAL_ID = RA.APPROVAL_ID)
-          AND T.ID = #{typeId}
+          AND A.TYPE_ID = #{typeId}
             LIMIT #{offset}, #{limit}
     </select>
 
@@ -182,7 +182,7 @@
                  JOIN tbl_approval A ON A.ID = RA.APPROVAL_ID
                  JOIN tbl_approval_type T ON A.TYPE_ID = T.ID
         WHERE RA.EMPLOYEE_ID = #{approverId}
-          AND T.ID = #{typeId}
+          AND A.TYPE_ID = #{typeId}
             LIMIT #{offset}, #{limit}
     </select>
 

--- a/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
+++ b/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
@@ -16,6 +16,7 @@ import org.triumers.kmsback.approval.query.dto.QryRequestApprovalWithEmployeeDTO
 import org.triumers.kmsback.common.LoggedInUser;
 import org.triumers.kmsback.common.TestUserInfo;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.user.command.Application.dto.ManageUserDTO;
 import org.triumers.kmsback.user.command.Application.service.AuthService;
 import org.triumers.kmsback.user.command.Application.service.ManagerService;
@@ -63,7 +64,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findByIdTest() throws NotLoginException {
+    public void findByIdTest() throws NotLoginException, WrongInputValueException {
         // given
         requesterSetUp();
         int requesterId = authService.whoAmI().getId();
@@ -84,7 +85,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findAllTest() throws NotLoginException {
+    public void findAllTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -101,7 +102,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findByTypeTest() throws NotLoginException {
+    public void findByTypeTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -122,7 +123,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findByDateRangeTest() throws NotLoginException {
+    public void findByDateRangeTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -144,7 +145,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findReceivedByIdTest() throws NotLoginException {
+    public void findReceivedByIdTest() throws NotLoginException, WrongInputValueException {
         // given
         approverSetUp();
         int approverId = authService.whoAmI().getId();
@@ -163,7 +164,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findAllReceivedTest() throws NotLoginException {
+    public void findAllReceivedTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -180,7 +181,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findReceivedByTypeTest() throws NotLoginException {
+    public void findReceivedByTypeTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -200,7 +201,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findReceivedByDateRangeTest() throws NotLoginException {
+    public void findReceivedByDateRangeTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -220,7 +221,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findByContentTest() throws NotLoginException {
+    public void findByContentTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -237,7 +238,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findByStatusTest() throws NotLoginException {
+    public void findByStatusTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -254,7 +255,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findReceivedByContentTest() throws NotLoginException {
+    public void findReceivedByContentTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수
@@ -271,7 +272,7 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @Test
-    public void findReceivedByStatusTest() throws NotLoginException {
+    public void findReceivedByStatusTest() throws NotLoginException, WrongInputValueException {
         // given
         int page = 1;
         int size = 10; // 한 페이지에 표시할 결과의 최대 개수

--- a/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
+++ b/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
@@ -64,7 +64,7 @@ class QryRequestApprovalServiceImplTests {
         approvalRepository.deleteAll();
     }
 
-    @DisplayName("본인이 요청한 결재 ID로 결재 단일 조회")
+    @DisplayName("본인이 요청한 결재 ID로 단일 조회")
     @Test
     public void findByIdTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -190,8 +190,7 @@ class QryRequestApprovalServiceImplTests {
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getIsApproved().equals(status)));
     }
 
-
-
+    @DisplayName("본인이 요청받은 결재 ID로 단일 조회")
     @Test
     public void findReceivedByIdTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -211,6 +210,7 @@ class QryRequestApprovalServiceImplTests {
         assertEquals("스터디 생성 요청", result.getApprovalInfo().getType());
     }
 
+    @DisplayName("본인이 요청받은 결재 전체 조회")
     @Test
     public void findAllReceivedTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -220,7 +220,8 @@ class QryRequestApprovalServiceImplTests {
         int approverId = authService.whoAmI().getId();
 
         // when
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findAllReceived(page, size);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                null, null, null, null, null, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -228,6 +229,7 @@ class QryRequestApprovalServiceImplTests {
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getApproverId() == approverId));
     }
 
+    @DisplayName("본인이 요청받은 결재 유형별 조회")
     @Test
     public void findReceivedByTypeTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -237,7 +239,8 @@ class QryRequestApprovalServiceImplTests {
         approverSetUp();
 
         // when
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedByType(typeId, page, size);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                typeId, null, null, null, null, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -248,6 +251,7 @@ class QryRequestApprovalServiceImplTests {
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getContent().equals("Test Content")));
     }
 
+    @DisplayName("본인이 요청받은 결재 기간별 조회")
     @Test
     public void findReceivedByDateRangeTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -258,7 +262,8 @@ class QryRequestApprovalServiceImplTests {
         approverSetUp();
 
         // when
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedByDateRange(startDate, endDate, page, size);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                null, startDate, endDate, null, null, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -268,6 +273,7 @@ class QryRequestApprovalServiceImplTests {
         ));
     }
 
+    @DisplayName("본인이 요청받은 결재 키워드로 검색")
     @Test
     public void findReceivedByContentTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -277,7 +283,8 @@ class QryRequestApprovalServiceImplTests {
         approverSetUp();
 
         // when
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedByContent(keyword, page, size);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                null, null, null, keyword, null, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -285,6 +292,7 @@ class QryRequestApprovalServiceImplTests {
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getContent().contains(keyword)));
     }
 
+    @DisplayName("본인이 요청받은 결재 승인 상태별 조회")
     @Test
     public void findReceivedByStatusTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -294,14 +302,14 @@ class QryRequestApprovalServiceImplTests {
         approverSetUp();
 
         // when
-        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedByStatus(status, page, size);
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                null, null, null, null, status, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
         assertEquals(expectedTotalCount, approvalInfoDTOS.size());
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getIsApproved().equals(status)));
     }
-
 
     private void addHrManagerForTest() {
         ManageUserDTO userDTO = new ManageUserDTO(TestUserInfo.HR_MANAGER_EMAIL, TestUserInfo.PASSWORD, TestUserInfo.NAME, null,

--- a/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
+++ b/src/test/java/org/triumers/kmsback/approval/query/service/QryRequestApprovalServiceImplTests.java
@@ -97,7 +97,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
-                null, null, null, null, null, page, size);
+                null, null, null, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -117,7 +117,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
-                typeId, null, null, null, null, page, size);
+                typeId, null, null, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -141,7 +141,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
-                null, startDate, endDate, null, null, page, size);
+                null, startDate, endDate, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -163,7 +163,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
-                null, null, null, keyword, null, page, size);
+                null, null, null, keyword, null, false, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -172,6 +172,25 @@ class QryRequestApprovalServiceImplTests {
     }
 
     @DisplayName("본인이 요청한 결재 승인 상태별 조회")
+    @Test
+    public void findQryRequestApprovalInfoByIsCanceledTest() throws NotLoginException, WrongInputValueException {
+        // given
+        int page = 1;
+        int size = 10;
+        boolean isCanceled = false;
+        requesterSetUp();
+
+        // when
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
+                null, null, null, null, null, isCanceled, page, size);
+
+        // then
+        int expectedTotalCount = 4; // 예상되는 총 결과 개수
+        assertEquals(expectedTotalCount, approvalInfoDTOS.size());
+        assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.isCanceled() == isCanceled));
+    }
+
+    @DisplayName("본인이 요청한 결재 취소 상태별 조회")
     @Test
     public void findQryRequestApprovalInfoByStatusTest() throws NotLoginException, WrongInputValueException {
         // given
@@ -182,13 +201,14 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findQryRequestApprovalInfo(
-                null, null, null, null, status, page, size);
+                null, null, null, null, status, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
         assertEquals(expectedTotalCount, approvalInfoDTOS.size());
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getIsApproved().equals(status)));
     }
+
 
     @DisplayName("본인이 요청받은 결재 ID로 단일 조회")
     @Test
@@ -221,7 +241,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
-                null, null, null, null, null, page, size);
+                null, null, null, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -240,7 +260,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
-                typeId, null, null, null, null, page, size);
+                typeId, null, null, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -263,7 +283,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
-                null, startDate, endDate, null, null, page, size);
+                null, startDate, endDate, null, null, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
@@ -284,7 +304,7 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
-                null, null, null, keyword, null, page, size);
+                null, null, null, keyword, null, false, page, size);
 
         // then
         int expectedTotalCount = 3; // 예상되는 총 결과 개수
@@ -303,12 +323,31 @@ class QryRequestApprovalServiceImplTests {
 
         // when
         List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
-                null, null, null, null, status, page, size);
+                null, null, null, null, status, false, page, size);
 
         // then
         int expectedTotalCount = 4; // 예상되는 총 결과 개수
         assertEquals(expectedTotalCount, approvalInfoDTOS.size());
         assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.getIsApproved().equals(status)));
+    }
+
+    @DisplayName("본인이 요청받은 결재 취소 상태별 조회")
+    @Test
+    public void findReceivedByIsCanceledTest() throws NotLoginException, WrongInputValueException {
+        // given
+        int page = 1;
+        int size = 10; // 한 페이지에 표시할 결과의 최대 개수
+        boolean isCanceled = false;
+        approverSetUp();
+
+        // when
+        List<QryRequestApprovalInfoDTO> approvalInfoDTOS = qryRequestApprovalService.findReceivedQryRequestApprovalInfo(
+                null, null, null, null, null, isCanceled, page, size);
+
+        // then
+        int expectedTotalCount = 4; // 예상되는 총 결과 개수
+        assertEquals(expectedTotalCount, approvalInfoDTOS.size());
+        assertTrue(approvalInfoDTOS.stream().allMatch(dto -> dto.isCanceled() == isCanceled));
     }
 
     private void addHrManagerForTest() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 및 구조 개선

### 반영 브랜치
feat/approval -> dev

### 변경 사항
- 결재 조회 메소드들 다중 조회 메소드 하나로 통일 및 수정
- 조회 쪽에서 쓰는 findEmployeeByName 메소드 cmd 메소드가 아닌 qry 메소드로 수정
- 페이징 처리 구현
- 취소된 결재 조회

### 테스트 결과
![image](https://github.com/Triumers/KMS-Back/assets/129481600/b162ee1c-3b9e-44e1-a157-0c0e4bf4e21e)