### PR TITLE
[Fix] 첫 로그인 시 비밀번호 변경 로직에서 토큰 안담기는 문제 개선

### DIFF
--- a/src/main/java/org/triumers/kmsback/common/auth/LoginFilter.java
+++ b/src/main/java/org/triumers/kmsback/common/auth/LoginFilter.java
@@ -85,9 +85,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.addHeader("Authorization", "Bearer " + token);
         response.addHeader("UserRole", role.name());
 
-        // Default 비밀번호인 경우 비밀번호 변경을 유도하기 위해 307 반환
+        // Default 비밀번호인 경우 비밀번호 변경을 유도하기 위해 210 반환
         if (bCryptPasswordEncoder.matches(defaultPassword, customUserDetails.getPassword())) {
-            response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+            response.setStatus(210);
             response.setCharacterEncoding("UTF-8");
             response.getWriter().write("비밀번호를 변경해주세요.");
             response.getWriter().flush();

--- a/src/main/java/org/triumers/kmsback/user/command/Application/controller/AuthController.java
+++ b/src/main/java/org/triumers/kmsback/user/command/Application/controller/AuthController.java
@@ -2,6 +2,7 @@ package org.triumers.kmsback.user.command.Application.controller;
 
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -26,6 +27,9 @@ import org.triumers.kmsback.common.exception.WrongInputValueException;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Value("${password}")
+    private String defaultPassword;
 
     @Autowired
     public AuthController(AuthService authService) {
@@ -56,6 +60,10 @@ public class AuthController {
 
         try {
             authService.editPassword(passwordDTO);
+
+            if (passwordDTO.getOldPassword().equals(defaultPassword)) {
+                return ResponseEntity.status(210).body(null);
+            }
 
             return ResponseEntity.status(HttpStatus.OK).body(
                     new CmdResponseMessageVO("비밀번호 변경 성공"));


### PR DESCRIPTION
반환 값이 2xx이 아닐 경우 토큰 저장을 잘 하지 못하는 문제를 발견해 210을 반환하도록 개선했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 및 구조 개선

### 반영 브랜치
feat/auth -> dev

### 변경 사항
첫 로그인 시 상태 값 반환이 2XX가 아닌 경우 토큰이 저장되지 않는 문제점을 발견하여 이를 개선했습니다.