### PR TITLE
[Refactor] 퇴사한 직원 포함 조회/Cmd -> Qry 변경

### DIFF
--- a/src/main/java/org/triumers/kmsback/post/query/controller/QryPostController.java
+++ b/src/main/java/org/triumers/kmsback/post/query/controller/QryPostController.java
@@ -3,16 +3,15 @@ package org.triumers.kmsback.post.query.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.triumers.kmsback.common.exception.NotLoginException;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.post.query.aggregate.vo.QryRequestPost;
 import org.triumers.kmsback.post.query.dto.QryPostAndTagsDTO;
 import org.triumers.kmsback.post.query.service.QryPostService;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
 
 import java.util.List;
 
@@ -28,7 +27,7 @@ public class QryPostController {
     }
 
     @PostMapping("/tab")
-    public ResponseEntity<Page<QryPostAndTagsDTO>> findPostListByTab(@RequestBody QryRequestPost request) throws NotLoginException {
+    public ResponseEntity<Page<QryPostAndTagsDTO>> findPostListByTab(@RequestBody QryRequestPost request) throws NotLoginException, WrongInputValueException {
 
         PageRequest pageable = PageRequest.of(request.getPage(), request.getSize());
         Page<QryPostAndTagsDTO> postList = qryPostService.findPostListByTab(request, pageable);
@@ -37,7 +36,7 @@ public class QryPostController {
     }
 
     @PostMapping("/tab/all")
-    public ResponseEntity<Page<QryPostAndTagsDTO>> findAllPostListByEmployee(@RequestBody QryRequestPost request) throws NotLoginException {
+    public ResponseEntity<Page<QryPostAndTagsDTO>> findAllPostListByEmployee(@RequestBody QryRequestPost request) throws NotLoginException, WrongInputValueException {
 
         PageRequest pageable = PageRequest.of(request.getPage(), request.getSize());
         Page<QryPostAndTagsDTO> postList = qryPostService.findAllPostListByEmployee(request, pageable);
@@ -46,22 +45,22 @@ public class QryPostController {
     }
 
     @GetMapping("find/{id}")
-    public ResponseEntity<QryPostAndTagsDTO> findPostById(@PathVariable int id) throws NotLoginException {
+    public ResponseEntity<QryPostAndTagsDTO> findPostById(@PathVariable int id) throws NotLoginException, WrongInputValueException {
         QryPostAndTagsDTO post = qryPostService.findPostById(id);
 
         return ResponseEntity.status(HttpStatus.OK).body(post);
     }
 
     @GetMapping("/{id}/history")
-    public ResponseEntity<List<QryPostAndTagsDTO>> findHistoryListByOriginId(@PathVariable int id) throws NotLoginException {
+    public ResponseEntity<List<QryPostAndTagsDTO>> findHistoryListByOriginId(@PathVariable int id) throws NotLoginException, WrongInputValueException {
         List<QryPostAndTagsDTO> history = qryPostService.findHistoryListByOriginId(id);
 
         return ResponseEntity.status(HttpStatus.OK).body(history);
     }
 
     @GetMapping("/{id}/like")
-    public ResponseEntity<List<CmdEmployeeDTO>> findLikeListByPostId(@PathVariable int id){
-        List<CmdEmployeeDTO> likeList = qryPostService.findLikeListByPostId(id);
+    public ResponseEntity<List<QryEmployeeDTO>> findLikeListByPostId(@PathVariable int id) throws WrongInputValueException {
+        List<QryEmployeeDTO> likeList = qryPostService.findLikeListByPostId(id);
 
         return ResponseEntity.status(HttpStatus.OK).body(likeList);
     }

--- a/src/main/java/org/triumers/kmsback/post/query/dto/QryPostAndTagsDTO.java
+++ b/src/main/java/org/triumers/kmsback/post/query/dto/QryPostAndTagsDTO.java
@@ -1,7 +1,7 @@
 package org.triumers.kmsback.post.query.dto;
 
 import lombok.Data;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,7 +13,7 @@ public class QryPostAndTagsDTO {
     private String content;
     private String postImg;
     private LocalDateTime createdAt;
-    private CmdEmployeeDTO author;
+    private QryEmployeeDTO author;
     private Integer originId;
     private Integer recentId;
     private Integer tabRelationId;
@@ -21,8 +21,8 @@ public class QryPostAndTagsDTO {
     private List<String> tags;
 
     private List<QryPostAndTagsDTO> history;
-    private List<CmdEmployeeDTO> participants;
-    private List<CmdEmployeeDTO> likeList;
+    private List<QryEmployeeDTO> participants;
+    private List<QryEmployeeDTO> likeList;
 
     private Boolean isLike;
     private Boolean isFavorite;
@@ -31,7 +31,7 @@ public class QryPostAndTagsDTO {
     }
 
     public QryPostAndTagsDTO(Integer id, String title, String content, String postImg, LocalDateTime createdAt,
-                             CmdEmployeeDTO author, Integer originId, Integer recentId, Integer tabRelationId,
+                             QryEmployeeDTO author, Integer originId, Integer recentId, Integer tabRelationId,
                              Integer categoryId, Boolean isLike, Boolean isFavorite) {
         this.id = id;
         this.title = title;
@@ -48,7 +48,7 @@ public class QryPostAndTagsDTO {
     }
 
     public QryPostAndTagsDTO(Integer id, String title, String content, String postImg, LocalDateTime createdAt,
-                             CmdEmployeeDTO author, Integer originId, Integer recentId, Integer tabRelationId,
+                             QryEmployeeDTO author, Integer originId, Integer recentId, Integer tabRelationId,
                              Integer categoryId) {
         this.id = id;
         this.title = title;

--- a/src/main/java/org/triumers/kmsback/post/query/service/QryPostService.java
+++ b/src/main/java/org/triumers/kmsback/post/query/service/QryPostService.java
@@ -3,23 +3,24 @@ package org.triumers.kmsback.post.query.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.triumers.kmsback.common.exception.NotLoginException;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.post.query.aggregate.vo.QryRequestPost;
 import org.triumers.kmsback.post.query.dto.QryPostAndTagsDTO;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
 
 import java.util.List;
 
 public interface QryPostService {
 
-    Page<QryPostAndTagsDTO> findPostListByTab(QryRequestPost request, Pageable pageable) throws NotLoginException;
+    Page<QryPostAndTagsDTO> findPostListByTab(QryRequestPost request, Pageable pageable) throws NotLoginException, WrongInputValueException;
 
-    Page<QryPostAndTagsDTO> findAllPostListByEmployee(QryRequestPost request, Pageable pageable) throws NotLoginException;
+    Page<QryPostAndTagsDTO> findAllPostListByEmployee(QryRequestPost request, Pageable pageable) throws NotLoginException, WrongInputValueException;
 
-    QryPostAndTagsDTO findPostById(int postId) throws NotLoginException;
+    QryPostAndTagsDTO findPostById(int postId) throws NotLoginException, WrongInputValueException;
 
-    List<QryPostAndTagsDTO> findHistoryListByOriginId(int originId) throws NotLoginException;
+    List<QryPostAndTagsDTO> findHistoryListByOriginId(int originId) throws NotLoginException, WrongInputValueException;
 
-    List<CmdEmployeeDTO> findLikeListByPostId(int postId);
+    List<QryEmployeeDTO> findLikeListByPostId(int postId) throws WrongInputValueException;
 
     Boolean getIsEditingById(int postId);
 

--- a/src/main/java/org/triumers/kmsback/post/query/service/QryPostServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/post/query/service/QryPostServiceImpl.java
@@ -5,11 +5,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.triumers.kmsback.common.exception.NotLoginException;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.group.query.service.QryGroupService;
 import org.triumers.kmsback.tab.command.Application.service.CmdTabService;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
 import org.triumers.kmsback.user.command.Application.service.AuthService;
-import org.triumers.kmsback.user.command.Application.service.CmdEmployeeService;
 import org.triumers.kmsback.post.query.aggregate.entity.QryLike;
 import org.triumers.kmsback.post.query.aggregate.entity.QryPostAndTag;
 import org.triumers.kmsback.post.query.aggregate.entity.QryTag;
@@ -17,6 +16,8 @@ import org.triumers.kmsback.post.query.aggregate.vo.QryRequestPost;
 import org.triumers.kmsback.post.query.dto.QryPostAndTagsDTO;
 import org.triumers.kmsback.post.query.repository.QryPostMapper;
 import org.triumers.kmsback.user.command.domain.aggregate.entity.Employee;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
+import org.triumers.kmsback.user.query.service.QryEmployeeService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,19 +26,19 @@ import java.util.List;
 public class QryPostServiceImpl implements QryPostService {
 
     private final QryPostMapper qryPostMapper;
-    private final CmdEmployeeService cmdEmployeeService;
+    private final QryEmployeeService qryEmployeeService;
     private final AuthService authService;
     private final QryGroupService qryGroupService;
 
-    public QryPostServiceImpl(QryPostMapper qryPostMapper, CmdEmployeeService cmdEmployeeService, CmdTabService cmdTabService, AuthService authService, QryGroupService qryGroupService) {
+    public QryPostServiceImpl(QryPostMapper qryPostMapper, QryEmployeeService qryEmployeeService, CmdTabService cmdTabService, AuthService authService, QryGroupService qryGroupService) {
         this.qryPostMapper = qryPostMapper;
-        this.cmdEmployeeService = cmdEmployeeService;
+        this.qryEmployeeService = qryEmployeeService;
         this.authService = authService;
         this.qryGroupService = qryGroupService;
     }
 
     @Override
-    public Page<QryPostAndTagsDTO> findPostListByTab(QryRequestPost request, Pageable pageable) throws NotLoginException {
+    public Page<QryPostAndTagsDTO> findPostListByTab(QryRequestPost request, Pageable pageable) throws NotLoginException, WrongInputValueException {
 
         List<QryPostAndTag> postList = qryPostMapper.selectTabPostList(request, pageable);
         for (int i = 0; i < postList.size(); i++) {
@@ -53,7 +54,7 @@ public class QryPostServiceImpl implements QryPostService {
     }
 
     @Override
-    public Page<QryPostAndTagsDTO> findAllPostListByEmployee(QryRequestPost request, Pageable pageable) throws NotLoginException {
+    public Page<QryPostAndTagsDTO> findAllPostListByEmployee(QryRequestPost request, Pageable pageable) throws NotLoginException, WrongInputValueException {
 
         Employee employee = authService.whoAmI();
 
@@ -66,10 +67,10 @@ public class QryPostServiceImpl implements QryPostService {
     }
 
     @Override
-    public QryPostAndTagsDTO findPostById(int postId) throws NotLoginException {
+    public QryPostAndTagsDTO findPostById(int postId) throws NotLoginException, WrongInputValueException {
         QryPostAndTag post = qryPostMapper.selectPostById(postId);
 
-        CmdEmployeeDTO employeeDTO = cmdEmployeeService.findEmployeeById(post.getAuthorId());
+        QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(post.getAuthorId());
 
         QryPostAndTagsDTO postDTO = new QryPostAndTagsDTO(post.getId(), post.getTitle(), post.getContent(),
                 post.getPostImg(), post.getCreatedAt(), employeeDTO, post.getOriginId(),
@@ -85,35 +86,39 @@ public class QryPostServiceImpl implements QryPostService {
         return postDTO;
     }
 
-    private List<CmdEmployeeDTO> findParticipantsListByOriginId(int postId) {
+    private List<QryEmployeeDTO> findParticipantsListByOriginId(int postId) throws WrongInputValueException {
 
-        List<CmdEmployeeDTO> participantList = new ArrayList<>();
+        List<QryEmployeeDTO> participantList = new ArrayList<>();
         List<Integer> employeeList = qryPostMapper.selectParticipantsListByOriginId(postId);
         for (int i = 0; i < employeeList.size(); i++) {
-            CmdEmployeeDTO employee = cmdEmployeeService.findEmployeeById(employeeList.get(i));
+            QryEmployeeDTO employee = qryEmployeeService.findEmployeeById(employeeList.get(i));
             participantList.add(employee);
         }
         return participantList;
     }
 
     @Override
-    public List<QryPostAndTagsDTO> findHistoryListByOriginId(int originId) throws NotLoginException {
+    public List<QryPostAndTagsDTO> findHistoryListByOriginId(int originId) throws NotLoginException, WrongInputValueException {
         List<QryPostAndTag> historyList = qryPostMapper.selectHistoryListByOriginId(originId);
 
         return QryPostAndTagListToDTOList(historyList, "history");
     }
 
     @Override
-    public List<CmdEmployeeDTO> findLikeListByPostId(int postId) {
+    public List<QryEmployeeDTO> findLikeListByPostId(int postId) throws WrongInputValueException {
 
         List<QryLike> likeList = qryPostMapper.selectLikeListByPostId(postId);
+        List<QryEmployeeDTO> likeMemberList = new ArrayList<>();
 
-        List<CmdEmployeeDTO> likeMemberList = new ArrayList<>();
-        for (int i = 0; i < likeList.size(); i++) {
-            int memberId = likeList.get(i).getEmployeeId();
-            CmdEmployeeDTO employeeDTO = cmdEmployeeService.findEmployeeById(memberId);
-            likeMemberList.add(employeeDTO);
+        if (likeList != null) {
+            for (int i = 0; i < likeList.size(); i++) {
+                int memberId = likeList.get(i).getEmployeeId();
+
+                QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(memberId);
+                likeMemberList.add(employeeDTO);
+            }
         }
+
         return likeMemberList;
     }
 
@@ -187,7 +192,7 @@ public class QryPostServiceImpl implements QryPostService {
     }
 
 
-    private List<QryPostAndTagsDTO> QryPostAndTagListToDTOList(List<QryPostAndTag> postList, String type) throws NotLoginException {
+    private List<QryPostAndTagsDTO> QryPostAndTagListToDTOList(List<QryPostAndTag> postList, String type) throws NotLoginException, WrongInputValueException {
 
         List<QryPostAndTagsDTO> postDTOList = new ArrayList<>();
         for (int i = 0; i < postList.size(); i++) {
@@ -199,7 +204,7 @@ public class QryPostServiceImpl implements QryPostService {
                 authorId = qryPostMapper.originAuthorId(originId);
             }
 
-            CmdEmployeeDTO employeeDTO = cmdEmployeeService.findEmployeeById(authorId);
+            QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(authorId);
 
             QryPostAndTagsDTO postDTO = new QryPostAndTagsDTO(post.getId(), post.getTitle(), post.getContent(),
                     post.getPostImg(), post.getCreatedAt(), employeeDTO, post.getOriginId(),
@@ -210,7 +215,7 @@ public class QryPostServiceImpl implements QryPostService {
             postDTO.setIsFavorite(findIsFavoriteByPostId(originId));
 
             if(type.equals("origin")){
-                List<CmdEmployeeDTO> like = findLikeListByPostId(originId);
+                List<QryEmployeeDTO> like = findLikeListByPostId(originId);
                 postDTO.setLikeList(like);
             }
             postDTOList.add(postDTO);

--- a/src/main/java/org/triumers/kmsback/post/query/service/QryPostServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/post/query/service/QryPostServiceImpl.java
@@ -70,7 +70,7 @@ public class QryPostServiceImpl implements QryPostService {
     public QryPostAndTagsDTO findPostById(int postId) throws NotLoginException, WrongInputValueException {
         QryPostAndTag post = qryPostMapper.selectPostById(postId);
 
-        QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(post.getAuthorId());
+        QryEmployeeDTO employeeDTO = qryEmployeeService.findByIdIncludeEnd(post.getAuthorId());
 
         QryPostAndTagsDTO postDTO = new QryPostAndTagsDTO(post.getId(), post.getTitle(), post.getContent(),
                 post.getPostImg(), post.getCreatedAt(), employeeDTO, post.getOriginId(),
@@ -91,7 +91,7 @@ public class QryPostServiceImpl implements QryPostService {
         List<QryEmployeeDTO> participantList = new ArrayList<>();
         List<Integer> employeeList = qryPostMapper.selectParticipantsListByOriginId(postId);
         for (int i = 0; i < employeeList.size(); i++) {
-            QryEmployeeDTO employee = qryEmployeeService.findEmployeeById(employeeList.get(i));
+            QryEmployeeDTO employee = qryEmployeeService.findByIdIncludeEnd(employeeList.get(i));
             participantList.add(employee);
         }
         return participantList;
@@ -114,7 +114,7 @@ public class QryPostServiceImpl implements QryPostService {
             for (int i = 0; i < likeList.size(); i++) {
                 int memberId = likeList.get(i).getEmployeeId();
 
-                QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(memberId);
+                QryEmployeeDTO employeeDTO = qryEmployeeService.findByIdIncludeEnd(memberId);
                 likeMemberList.add(employeeDTO);
             }
         }
@@ -204,7 +204,7 @@ public class QryPostServiceImpl implements QryPostService {
                 authorId = qryPostMapper.originAuthorId(originId);
             }
 
-            QryEmployeeDTO employeeDTO = qryEmployeeService.findEmployeeById(authorId);
+            QryEmployeeDTO employeeDTO = qryEmployeeService.findByIdIncludeEnd(authorId);
 
             QryPostAndTagsDTO postDTO = new QryPostAndTagsDTO(post.getId(), post.getTitle(), post.getContent(),
                     post.getPostImg(), post.getCreatedAt(), employeeDTO, post.getOriginId(),

--- a/src/main/java/org/triumers/kmsback/user/query/controller/QryEmployeeController.java
+++ b/src/main/java/org/triumers/kmsback/user/query/controller/QryEmployeeController.java
@@ -33,6 +33,17 @@ public class QryEmployeeController {
         }
     }
 
+    @GetMapping("/id-with/{id}")
+    public ResponseEntity<QryResponseEmployeeVO> findByIdIncludeEnd(@PathVariable int id) {
+
+        try {
+            QryEmployeeDTO employee = qryEmployeeService.findByIdIncludeEnd(id);
+            return ResponseEntity.status(HttpStatus.OK).body(new QryResponseEmployeeVO("조회 성공", List.of(employee)));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new QryResponseEmployeeVO("조회 실패", null));
+        }
+    }
+
     @GetMapping("/all")
     public ResponseEntity<QryResponseEmployeeVO> findAll() {
 

--- a/src/main/java/org/triumers/kmsback/user/query/repository/EmployeeMapper.java
+++ b/src/main/java/org/triumers/kmsback/user/query/repository/EmployeeMapper.java
@@ -19,4 +19,6 @@ public interface EmployeeMapper {
     List<QryEmployee> findByTeamId(int teamId);
 
     List<QryEmployee> findSimpleInfoByTeamId(int teamId);
+
+    QryEmployee findByIdIncludeEnd(int id);
 }

--- a/src/main/java/org/triumers/kmsback/user/query/service/QryAuthServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/user/query/service/QryAuthServiceImpl.java
@@ -104,6 +104,7 @@ public class QryAuthServiceImpl implements QryAuthService {
             Map<String, String> postMap = new HashMap<>();
             postMap.put("id", String.valueOf(post.getId()));
             postMap.put("title", post.getTitle());
+            postMap.put("originId", String.valueOf(post.getOriginId()));
             myPostListDTO.add(postMap);
         }
         result.setDocsInfoList(myPostListDTO);

--- a/src/main/java/org/triumers/kmsback/user/query/service/QryEmployeeService.java
+++ b/src/main/java/org/triumers/kmsback/user/query/service/QryEmployeeService.java
@@ -18,4 +18,6 @@ public interface QryEmployeeService {
     List<QryEmployeeDTO> findEmployeeByTeamId(int teamId) throws WrongInputValueException;
 
     List<QryEmployeeDTO> findSimpleInfoByTeamId(int teamId);
+
+    QryEmployeeDTO findByIdIncludeEnd(int id) throws WrongInputValueException;
 }

--- a/src/main/java/org/triumers/kmsback/user/query/service/QryEmployeeServiceImpl.java
+++ b/src/main/java/org/triumers/kmsback/user/query/service/QryEmployeeServiceImpl.java
@@ -99,6 +99,13 @@ public class QryEmployeeServiceImpl implements QryEmployeeService {
         return employeeDTOList;
     }
 
+    @Override
+    public QryEmployeeDTO findByIdIncludeEnd(int id) throws WrongInputValueException {
+        QryEmployee employee = employeeMapper.findByIdIncludeEnd(id);
+
+        return employeeToDTO(employee);
+    }
+
     private QryEmployeeDTO employeeToDTO(QryEmployee employee) throws WrongInputValueException {
 
         Map<String, String> team = new HashMap<>();

--- a/src/main/resources/org/triumers/kmsback/user/query/repository/EmployeeMapper.xml
+++ b/src/main/resources/org/triumers/kmsback/user/query/repository/EmployeeMapper.xml
@@ -25,6 +25,12 @@
            AND END_DATE IS NULL
     </select>
 
+    <select id="findByIdIncludeEnd" resultMap="employeeMap" parameterType="int">
+        SELECT *
+          FROM tbl_employee
+         WHERE ID = #{id}
+    </select>
+
     <select id="findAllEmployee" resultMap="employeeMap">
         SELECT *
           FROM tbl_employee

--- a/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.triumers.kmsback.common.LoggedInUser;
 import org.triumers.kmsback.common.exception.NotLoginException;
 import org.triumers.kmsback.common.exception.WrongInputTypeException;
+import org.triumers.kmsback.common.exception.WrongInputValueException;
 import org.triumers.kmsback.post.command.Application.dto.CmdLikeDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdFavoritesDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdPostAndTagsDTO;
@@ -48,7 +49,7 @@ class QryPostServiceTest {
     }
     @Test
     @DisplayName("tab 게시글 리스트 조회")
-    void findPostListByTab() throws NotLoginException {
+    void findPostListByTab() throws NotLoginException, WrongInputValueException {
 
         registPost();
 
@@ -63,7 +64,7 @@ class QryPostServiceTest {
 
     @Test
     @DisplayName("회원이 속한 전체 게시글 리스트 조회")
-    void findAllPostListByTab() throws NotLoginException {
+    void findAllPostListByTab() throws NotLoginException, WrongInputValueException {
 
         registPost();
 
@@ -78,7 +79,7 @@ class QryPostServiceTest {
 
     @Test
     @DisplayName("단일 게시글 조회")
-    void findPostById() throws NotLoginException {
+    void findPostById() throws NotLoginException, WrongInputValueException {
 
         CmdPostAndTagsDTO post = registPost();
         QryPostAndTagsDTO selectedPost = qryPostService.findPostById(post.getId());
@@ -144,7 +145,7 @@ class QryPostServiceTest {
 
     @Test
     @DisplayName("게시글 히스토리 조회")
-    void findHistoryListByOriginId() throws NotLoginException {
+    void findHistoryListByOriginId() throws NotLoginException, WrongInputValueException {
 
         int originId = modifyPost();
         List<QryPostAndTagsDTO> history = qryPostService.findHistoryListByOriginId(originId);
@@ -154,7 +155,7 @@ class QryPostServiceTest {
 
     @Test
     @DisplayName("게시글 좋아요 리스트 조회")
-    void findLikeListByPostId() throws NotLoginException {
+    void findLikeListByPostId() throws NotLoginException, WrongInputValueException {
 
         CmdPostAndTagsDTO post = registPost();
         CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, post.getId());

--- a/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
+++ b/src/test/java/org/triumers/kmsback/post/query/service/QryPostServiceTest.java
@@ -12,12 +12,12 @@ import org.triumers.kmsback.common.LoggedInUser;
 import org.triumers.kmsback.common.exception.NotLoginException;
 import org.triumers.kmsback.common.exception.WrongInputTypeException;
 import org.triumers.kmsback.post.command.Application.dto.CmdLikeDTO;
-import org.triumers.kmsback.user.command.Application.dto.CmdEmployeeDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdFavoritesDTO;
 import org.triumers.kmsback.post.command.Application.dto.CmdPostAndTagsDTO;
 import org.triumers.kmsback.post.command.Application.service.CmdPostService;
 import org.triumers.kmsback.post.query.aggregate.vo.QryRequestPost;
 import org.triumers.kmsback.post.query.dto.QryPostAndTagsDTO;
+import org.triumers.kmsback.user.query.dto.QryEmployeeDTO;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -160,7 +160,7 @@ class QryPostServiceTest {
         CmdFavoritesDTO favorite = new CmdFavoritesDTO(1, post.getId());
         cmdPostService.favoritePost(favorite);
 
-        List<CmdEmployeeDTO> likeList = qryPostService.findLikeListByPostId(post.getId());
+        List<QryEmployeeDTO> likeList = qryPostService.findLikeListByPostId(post.getId());
 
         assertThat(likeList).isNotNull();
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 및 구조 개선

### 반영 브랜치
feat/post -> dev

### 변경 사항
- Auth서비스에 퇴사한 직원을 포함해 조회하는 함수 추가
- post 관련 직원 조회 추가한 함수로 변경
- post Employee 받아오는 부분 Cmd -> Qry로 변경
- my-post like/favorite에 originId 추가

### 테스트 결과
![image](https://github.com/Triumers/KMS-Back/assets/34918049/702f476d-2344-43dc-af51-0d682ffd877d)
