### PR TITLE
[Fix] 외부망 접속 시 2차 인증 버그 수정

### DIFF
--- a/src/main/java/org/triumers/kmsback/common/auth/LoginFilter.java
+++ b/src/main/java/org/triumers/kmsback/common/auth/LoginFilter.java
@@ -31,7 +31,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final String defaultPassword;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    @Value("in-house-ip-address")
+    @Value("${in-house-ip-address}")
     private String defaultIpAddress;
 
     private final OTPValidator otpValidator;
@@ -74,14 +74,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String clientIpAddress = IpAddressUtil.getClientIp(request);
 
-//        // Authenticator 등록된 계정 2차 인증
-//        if (!clientIpAddress.equals(defaultIpAddress) && !clientIpAddress.equals("0:0:0:0:0:0:0:1")) {
-//            if (!otpValidator.validateOTP(secret, otpCode)) {
-//                throw new BadCredentialsException("Invalid OTP");
-//            }
-//        }
+        // 내부망 또는 개발환경인지 검증하는 로직
+        if (!clientIpAddress.equals(defaultIpAddress) && !clientIpAddress.equals("0:0:0:0:0:0:0:1")) {
 
-        if (secret != null && !secret.isEmpty()) {
+            // 2차 인증
             if (!otpValidator.validateOTP(secret, otpCode)) {
                 throw new BadCredentialsException("Invalid OTP");
             }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 및 구조 개선

### 반영 브랜치
main -> hotfix

### 변경 사항
외부망 접속 시 2차 인증을 진행하는 로직에서 발생한 버그를 수정했습니다.
이제 내부망 접속 시에는 로그인을 요구하지 않습니다.