### PR TITLE
[Fix] 외부망 접속 시 2차 인증 버그 수정

### DIFF
--- a/src/main/java/org/triumers/kmsback/user/command/Application/controller/AuthController.java
+++ b/src/main/java/org/triumers/kmsback/user/command/Application/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
     @Value("${password}")
     private String defaultPassword;
 
-    @Value("in-house-ip-address")
+    @Value("${in-house-ip-address}")
     private String defaultIpAddress;
 
     @Autowired
@@ -52,7 +52,7 @@ public class AuthController {
 
             if (authService.isHaveAuthenticator(account)) {
 
-                if (IpAddressUtil.getClientIp(request).equals(defaultIpAddress) ||
+                if (IpAddressUtil.getClientIp(request).equals("121.170.161.69") ||
                         IpAddressUtil.getClientIp(request).equals("0:0:0:0:0:0:0:1")) {
                     return ResponseEntity.status(HttpStatus.OK).body(new CmdResponseMessageVO("환영합니다."));
                 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드 및 구조 개선

### 반영 브랜치
hotfix -> main

### 변경 사항
yml로부터 값을 못읽어오는 문제를 확인하여 우선 하드코딩으로 해결했습니다.