### PR TITLE
[Refactor] 테스트 계정 생성 개선

### DIFF
--- a/src/test/java/org/triumers/kmsback/common/LoggedInUser.java
+++ b/src/test/java/org/triumers/kmsback/common/LoggedInUser.java
@@ -6,7 +6,16 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.triumers.kmsback.organization.command.Application.dto.CmdCenterDTO;
+import org.triumers.kmsback.organization.command.Application.dto.CmdDepartmentDTO;
+import org.triumers.kmsback.organization.command.Application.dto.CmdTeamDTO;
+import org.triumers.kmsback.organization.command.Application.service.CmdCenterService;
+import org.triumers.kmsback.organization.command.Application.service.CmdDepartmentService;
+import org.triumers.kmsback.organization.command.Application.service.CmdTeamService;
+import org.triumers.kmsback.user.command.Application.dto.CmdPositionDTO;
+import org.triumers.kmsback.user.command.Application.dto.CmdRankDTO;
 import org.triumers.kmsback.user.command.Application.dto.ManageUserDTO;
+import org.triumers.kmsback.user.command.Application.service.CmdDutyService;
 import org.triumers.kmsback.user.command.Application.service.ManagerService;
 import org.triumers.kmsback.user.command.domain.repository.EmployeeRepository;
 import org.triumers.kmsback.user.command.domain.service.CustomUserDetailsService;
@@ -27,11 +36,69 @@ public class LoggedInUser {
     @Autowired
     private EmployeeRepository employeeRepository;
 
+    @Autowired
+    private CmdCenterService cmdCenterService;
+
+    @Autowired
+    private CmdDepartmentService cmdDepartmentService;
+
+    @Autowired
+    private CmdTeamService cmdTeamService;
+
+    @Autowired
+    private CmdDutyService cmdDutyService;
+
+    // 테스트용 본부 생성
+    private int addCenterForTest() {
+        CmdCenterDTO centerDTO = new CmdCenterDTO();
+        centerDTO.setName("UniqueCenterNameForTest");
+        return cmdCenterService.addCenter(centerDTO);
+    }
+
+    // 테스트용 부서 생성
+    private int addDepartmentForTest() {
+        int centerId = addCenterForTest();
+        CmdDepartmentDTO departmentDTO = new CmdDepartmentDTO();
+        departmentDTO.setName("UniqDepartmentNameForTest");
+        departmentDTO.setCenterId(centerId);
+        return cmdDepartmentService.addDepartment(departmentDTO);
+    }
+
+    // 테스트용 팀 생성
+    private int addTeamForTest() {
+        int departmentId = addDepartmentForTest();
+        CmdTeamDTO teamDTO = new CmdTeamDTO();
+        teamDTO.setName("UniqTeamNameForTest");
+        teamDTO.setDepartmentId(departmentId);
+
+        return cmdTeamService.addTeam(teamDTO);
+    }
+
+    // 테스트용 직책 생성
+    private int addPositionForTest() {
+        CmdPositionDTO positionDTO = new CmdPositionDTO();
+        positionDTO.setName("UniqPositionNameForTest");
+
+        return cmdDutyService.addPosition(positionDTO);
+    }
+
+    // 테스트용 직급 생성
+    private int addRankForTest() {
+        CmdRankDTO rankDTO = new CmdRankDTO();
+        rankDTO.setName("UniqRankNameForTest");
+
+        return cmdDutyService.addRank(rankDTO);
+    }
+
     // 테스트용 계정 DTO 생성
     private ManageUserDTO createRightAuthDTO() {
+        int teamId = addTeamForTest();
+        int positionId = addPositionForTest();
+        int rankId = addRankForTest();
+
         return new ManageUserDTO(RIGHT_FORMAT_EMAIL, RIGHT_FORMAT_PASSWORD, RIGHT_FORMAT_NAME, null,
-                RIGHT_FORMAT_USER_ROLE, null, null, RIGHT_PHONE_NUMBER, 1, 1,
-                1);
+                RIGHT_FORMAT_USER_ROLE, null, null, RIGHT_PHONE_NUMBER, teamId, positionId,
+                rankId);
     }
 
     // 테스트용 관리자 계정 DTO 생성


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 및 구조 개선

### 반영 브랜치
feat/auth -> dev

### 변경 사항
테스트 계정 생성 시 더미 값을 이용하던 부분을 전부 없앴습니다.
이제는 더미 값 대신 테스트 용 값을 직접 생성해 테스트합니다.
더 이상 DB에 얽매이지 않고 마음껏 테스트 용 계정을 생성하시길 바랍니다.